### PR TITLE
feat: admin UI overhaul — dark mode, skeletons, logo, polish

### DIFF
--- a/apps/docs/src/assets/logo-dark.svg
+++ b/apps/docs/src/assets/logo-dark.svg
@@ -1,4 +1,7 @@
-<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <rect width="32" height="32" rx="8" fill="#10b981"/>
-  <text x="16" y="22" text-anchor="middle" font-family="system-ui" font-weight="700" font-size="18" fill="#0a0f1a">W</text>
+<svg width="32" height="32" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="512" height="512" rx="128" fill="#10B981"/>
+  <rect x="110" y="110" width="292" height="55" rx="18" fill="white"/>
+  <rect x="110" y="195" width="180" height="207" rx="18" fill="white"/>
+  <rect x="320" y="195" width="82" height="91" rx="18" fill="white"/>
+  <rect x="320" y="311" width="82" height="91" rx="18" fill="white"/>
 </svg>

--- a/apps/docs/src/assets/logo-light.svg
+++ b/apps/docs/src/assets/logo-light.svg
@@ -1,4 +1,7 @@
-<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <rect width="32" height="32" rx="8" fill="#10b981"/>
-  <text x="16" y="22" text-anchor="middle" font-family="system-ui" font-weight="700" font-size="18" fill="#0a0f1a">W</text>
+<svg width="32" height="32" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="512" height="512" rx="128" fill="#10B981"/>
+  <rect x="110" y="110" width="292" height="55" rx="18" fill="white"/>
+  <rect x="110" y="195" width="180" height="207" rx="18" fill="white"/>
+  <rect x="320" y="195" width="82" height="91" rx="18" fill="white"/>
+  <rect x="320" y="311" width="82" height="91" rx="18" fill="white"/>
 </svg>

--- a/apps/docs/src/content/docs/concepts/admin-ui.md
+++ b/apps/docs/src/content/docs/concepts/admin-ui.md
@@ -1,0 +1,99 @@
+---
+title: Admin UI
+description: Overview of the WollyCMS admin interface — theming, keyboard shortcuts, and customization.
+---
+
+The WollyCMS admin is a single-page application built with SvelteKit. It runs at `/admin` on your CMS domain (e.g., `https://cms.example.com/admin`).
+
+## Theme
+
+The admin supports three theme modes: **Light**, **Dark**, and **System** (follows your OS preference).
+
+### Switching themes
+
+Click the theme icon in the bottom-left of the sidebar to cycle between modes:
+- Sun — Light mode
+- Moon — Dark mode
+- Monitor — System (auto-detects OS preference)
+
+Your choice is saved in the browser and persists across sessions. There is no white flash on page load — the theme is applied before the page renders.
+
+### CSS variables
+
+The admin uses CSS custom properties for all colors. Both light and dark themes are defined in `packages/admin/src/app.css`. Key variables:
+
+| Variable | Purpose |
+|---|---|
+| `--c-bg` | Page background |
+| `--c-bg-subtle` | Subtle background (hover states, table headers) |
+| `--c-surface` | Card, modal, and input backgrounds |
+| `--c-text` | Primary text |
+| `--c-text-light` | Secondary/muted text |
+| `--c-border` | Borders and dividers |
+| `--c-accent` | Primary accent (links, active states, focus rings) |
+| `--c-danger` | Destructive actions |
+| `--c-success` | Success states |
+| `--c-warning` | Warning states |
+| `--c-sidebar` | Sidebar background |
+
+Custom block type editors and admin extensions should use these variables to automatically support both themes.
+
+## Branding
+
+The admin displays your site name in the sidebar header. Configure it in **System → Settings** under the "Admin Brand Name" field. The logo is the WollyCMS block composition icon by default.
+
+## Keyboard shortcuts
+
+| Shortcut | Action |
+|---|---|
+| `Ctrl+K` | Open global search |
+| `Ctrl+S` | Save current page (in page editor) |
+| `Ctrl+Shift+P` | Toggle preview panel (in page editor) |
+| `?` | Show keyboard shortcuts overlay |
+| `Esc` | Close overlay/modal |
+
+## Global search
+
+Press `Ctrl+K` from anywhere in the admin to open the global search. It searches across pages, blocks, media, and menus. Results are grouped by type.
+
+## Dashboard
+
+The dashboard shows:
+- **Quick actions** — New Page, Upload Media, View Site (links to your `SITE_URL`)
+- **Stats** — Total pages, published, drafts, shared blocks, media, menus, users
+- **Recent pages** — Last updated pages with direct edit links
+
+## Loading states
+
+Pages show animated skeleton placeholders while data loads. The dashboard, pages list, and media grid all use shimmer skeletons instead of blank screens or spinner text.
+
+## Sidebar navigation
+
+The sidebar organizes admin features into sections:
+
+- **Content** — Pages, Blocks, Media
+- **Structure** — Menus, Taxonomies, Redirects
+- **Schema** — Content Types, Block Types
+- **System** — Users, Webhooks, API Keys, Tracking Scripts, Audit Log, Account, Settings
+
+On narrow screens (< 1024px), the sidebar collapses to icon-only mode with hover tooltips.
+
+## Page editor
+
+The page editor is the core editing experience:
+
+- **Title area** — Notion-style large title input with inline slug editor
+- **Status pill** — Colored badge showing Published/Draft/Archived
+- **Regions** — Color-coded content areas (Hero, Content, Sidebar, etc.)
+- **Block cards** — Collapsible cards with type badges, position numbers, and quick actions
+- **Preview panel** — Split-pane live preview with device size toggle (mobile/tablet/desktop)
+- **SEO sidebar** — Meta title/description, OG image, canonical URL, robots, SERP preview, social preview, SEO score
+- **Accessibility panel** — WCAG AA compliance checker
+- **Revision history** — View and restore previous versions
+
+### Block editing
+
+- Click the **+** button on a region to add a block (visual type picker with icons)
+- Hover a block card for quick actions (Edit, Duplicate, Move to Region, Remove)
+- Drag blocks to reorder within or across regions
+- Use `/` in the rich text editor for slash commands (headings, lists, tables, images)

--- a/packages/admin/src/app.css
+++ b/packages/admin/src/app.css
@@ -123,8 +123,20 @@ button:focus-visible,
   align-items: center;
   justify-content: center;
   height: 100vh;
-  font-size: 1.1rem;
   color: var(--c-text-light);
+}
+
+.loading-spinner {
+  width: 32px;
+  height: 32px;
+  border: 3px solid var(--c-border);
+  border-top-color: var(--c-accent);
+  border-radius: 50%;
+  animation: spin 0.6s linear infinite;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
 }
 
 /* Admin layout */
@@ -658,6 +670,60 @@ select.form-control {
 
 .empty-state p {
   margin-bottom: 1rem;
+}
+
+.empty-state-icon {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 1rem;
+  color: var(--c-border);
+}
+
+.empty-state-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--c-text);
+  margin-bottom: 0.25rem;
+}
+
+/* Skeleton loading */
+.skeleton {
+  background: linear-gradient(90deg, var(--c-bg-subtle) 25%, var(--c-border) 50%, var(--c-bg-subtle) 75%);
+  background-size: 200% 100%;
+  animation: skeleton-shimmer 1.5s ease-in-out infinite;
+  border-radius: var(--radius);
+}
+
+.skeleton-text {
+  height: 0.9rem;
+  margin-bottom: 0.5rem;
+  border-radius: 4px;
+}
+
+.skeleton-text:last-child {
+  width: 60%;
+}
+
+.skeleton-title {
+  height: 1.5rem;
+  width: 40%;
+  margin-bottom: 1rem;
+  border-radius: 4px;
+}
+
+.skeleton-card {
+  height: 80px;
+  margin-bottom: 0.75rem;
+}
+
+.skeleton-row {
+  height: 52px;
+  margin-bottom: 1px;
+}
+
+@keyframes skeleton-shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
 }
 
 /* Grid layout for forms */

--- a/packages/admin/src/app.css
+++ b/packages/admin/src/app.css
@@ -16,6 +16,7 @@
   --c-warning: #d69e2e;
   --c-bg: #f7f8fa;
   --c-bg-subtle: #f1f5f9;
+  --c-bg-alt: #f1f5f9;
   --c-surface: #ffffff;
   --c-text: #2d3748;
   --c-text-light: #5a6878;
@@ -31,8 +32,8 @@
 }
 
 [data-theme="dark"] {
-  --c-primary: #90cdf4;
-  --c-primary-light: #63b3ed;
+  --c-primary: #2b6cb0;
+  --c-primary-light: #3182ce;
   --c-accent: #63b3ed;
   --c-accent-muted: rgba(99, 179, 237, 0.15);
   --c-danger: #fc8181;
@@ -40,6 +41,7 @@
   --c-warning: #f6e05e;
   --c-bg: #0f1219;
   --c-bg-subtle: #171c28;
+  --c-bg-alt: #171c28;
   --c-surface: #1a2030;
   --c-text: #e2e8f0;
   --c-text-light: #94a3b8;
@@ -57,6 +59,21 @@ body {
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
   transition: background var(--transition), color var(--transition);
+}
+
+/* Global link colors (prevent browser default purple visited links) */
+a {
+  color: var(--c-accent);
+}
+
+a:visited {
+  color: var(--c-accent);
+}
+
+/* Checkbox and radio visibility in dark mode */
+input[type="checkbox"],
+input[type="radio"] {
+  accent-color: var(--c-accent);
 }
 
 /* Smooth theme transitions on key elements */

--- a/packages/admin/src/app.css
+++ b/packages/admin/src/app.css
@@ -149,12 +149,13 @@ button:focus-visible,
   justify-content: center;
   width: 28px;
   height: 28px;
-  background: var(--c-accent);
-  border-radius: 6px;
-  font-size: 0.9rem;
-  font-weight: 800;
-  letter-spacing: 0;
   flex-shrink: 0;
+}
+
+.logo-icon svg {
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
 }
 
 .logo-text {

--- a/packages/admin/src/app.css
+++ b/packages/admin/src/app.css
@@ -10,20 +10,44 @@
   --c-primary: #1a365d;
   --c-primary-light: #2a4a7f;
   --c-accent: #3182ce;
+  --c-accent-muted: rgba(49, 130, 206, 0.15);
   --c-danger: #e53e3e;
   --c-success: #38a169;
   --c-warning: #d69e2e;
   --c-bg: #f7f8fa;
+  --c-bg-subtle: #f1f5f9;
   --c-surface: #ffffff;
   --c-text: #2d3748;
   --c-text-light: #5a6878;
   --c-border: #e2e8f0;
   --c-sidebar: #1a202c;
+  --c-focus-ring: rgba(49, 130, 206, 0.15);
   --font: 'Inter', system-ui, -apple-system, sans-serif;
-  --radius: 6px;
-  --shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
-  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.1);
+  --radius: 8px;
+  --shadow: 0 1px 3px rgba(0, 0, 0, 0.06), 0 1px 2px rgba(0, 0, 0, 0.04);
+  --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.08);
   --sidebar-w: 240px;
+  --transition: 0.15s ease;
+}
+
+[data-theme="dark"] {
+  --c-primary: #90cdf4;
+  --c-primary-light: #63b3ed;
+  --c-accent: #63b3ed;
+  --c-accent-muted: rgba(99, 179, 237, 0.15);
+  --c-danger: #fc8181;
+  --c-success: #68d391;
+  --c-warning: #f6e05e;
+  --c-bg: #0f1219;
+  --c-bg-subtle: #171c28;
+  --c-surface: #1a2030;
+  --c-text: #e2e8f0;
+  --c-text-light: #94a3b8;
+  --c-border: #2d3748;
+  --c-sidebar: #0c1017;
+  --c-focus-ring: rgba(99, 179, 237, 0.2);
+  --shadow: 0 1px 3px rgba(0, 0, 0, 0.3), 0 1px 2px rgba(0, 0, 0, 0.2);
+  --shadow-md: 0 4px 16px rgba(0, 0, 0, 0.4);
 }
 
 body {
@@ -32,6 +56,12 @@ body {
   background: var(--c-bg);
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
+  transition: background var(--transition), color var(--transition);
+}
+
+/* Smooth theme transitions on key elements */
+.card, .table-wrap, .stat-card, .modal, .form-control, .alert, .badge {
+  transition: background var(--transition), border-color var(--transition), color var(--transition), box-shadow var(--transition);
 }
 
 /* Skip link for keyboard navigation */
@@ -237,6 +267,24 @@ button:focus-visible,
   gap: 0.5rem;
 }
 
+.btn-theme-toggle {
+  background: none;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+  color: rgba(255, 255, 255, 0.6);
+  cursor: pointer;
+  padding: 0.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius);
+  transition: background var(--transition), color var(--transition);
+}
+
+.btn-theme-toggle:hover {
+  background: rgba(255, 255, 255, 0.1);
+  color: white;
+}
+
 .btn-shortcut-hint {
   background: none;
   border: none;
@@ -351,7 +399,7 @@ tr:last-child td {
 }
 
 tr:hover td {
-  background: rgba(0, 0, 0, 0.015);
+  background: var(--c-bg-subtle);
 }
 
 /* Buttons */
@@ -404,7 +452,7 @@ tr:hover td {
 }
 
 .btn-danger-outline:hover {
-  background: #fef2f2;
+  background: color-mix(in srgb, var(--c-danger), transparent 90%);
 }
 
 .btn-sm {
@@ -453,7 +501,7 @@ tr:hover td {
 .form-control:focus {
   outline: none;
   border-color: var(--c-accent);
-  box-shadow: 0 0 0 3px rgba(49, 130, 206, 0.15);
+  box-shadow: 0 0 0 3px var(--c-focus-ring);
 }
 
 textarea.form-control {
@@ -476,18 +524,18 @@ select.form-control {
 }
 
 .badge-published {
-  background: #c6f6d5;
-  color: #22543d;
+  background: color-mix(in srgb, var(--c-success), transparent 80%);
+  color: var(--c-success);
 }
 
 .badge-draft {
-  background: #fefcbf;
-  color: #744210;
+  background: color-mix(in srgb, var(--c-warning), transparent 80%);
+  color: var(--c-warning);
 }
 
 .badge-archived {
-  background: #e2e8f0;
-  color: #4a5568;
+  background: var(--c-bg-subtle);
+  color: var(--c-text-light);
 }
 
 /* Stats grid */
@@ -572,15 +620,15 @@ select.form-control {
 }
 
 .alert-error {
-  background: #fed7d7;
-  color: #9b2c2c;
-  border: 1px solid #feb2b2;
+  background: color-mix(in srgb, var(--c-danger), transparent 85%);
+  color: var(--c-danger);
+  border: 1px solid color-mix(in srgb, var(--c-danger), transparent 70%);
 }
 
 .alert-success {
-  background: #c6f6d5;
-  color: #22543d;
-  border: 1px solid #9ae6b4;
+  background: color-mix(in srgb, var(--c-success), transparent 85%);
+  color: var(--c-success);
+  border: 1px solid color-mix(in srgb, var(--c-success), transparent 70%);
 }
 
 /* Empty state */

--- a/packages/admin/src/app.css
+++ b/packages/admin/src/app.css
@@ -32,6 +32,7 @@
 }
 
 [data-theme="dark"] {
+  color-scheme: dark;
   --c-primary: #2b6cb0;
   --c-primary-light: #3182ce;
   --c-accent: #63b3ed;

--- a/packages/admin/src/app.html
+++ b/packages/admin/src/app.html
@@ -7,6 +7,16 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
     <title>WollyCMS Admin</title>
+    <script>
+      // Apply theme before render to prevent flash
+      (function() {
+        var t = localStorage.getItem('wolly_theme') || 'system';
+        var r = t === 'system'
+          ? (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+          : t;
+        document.documentElement.dataset.theme = r;
+      })();
+    </script>
     %sveltekit.head%
   </head>
   <body data-sveltekit-prerender="false">

--- a/packages/admin/src/app.html
+++ b/packages/admin/src/app.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="icon" type="image/svg+xml" href="/admin/favicon.svg" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />

--- a/packages/admin/src/lib/components/AccessibilityPanel.svelte
+++ b/packages/admin/src/lib/components/AccessibilityPanel.svelte
@@ -102,13 +102,13 @@
   }
 
   .a11y-pass {
-    background: #dcfce7;
-    color: #16a34a;
+    background: color-mix(in srgb, var(--c-success), transparent 80%);
+    color: var(--c-success);
   }
 
   .a11y-warn {
-    background: #fef3c7;
-    color: #d97706;
+    background: color-mix(in srgb, var(--c-warning), transparent 80%);
+    color: var(--c-warning);
   }
 
   .a11y-chevron {
@@ -130,7 +130,7 @@
 
   .a11y-ok {
     font-size: 0.8rem;
-    color: #16a34a;
+    color: var(--c-success);
     margin: 0;
   }
 
@@ -157,8 +157,8 @@
   .a11y-group-count {
     font-size: 0.65rem;
     font-weight: 700;
-    background: #fef3c7;
-    color: #d97706;
+    background: color-mix(in srgb, var(--c-warning), transparent 80%);
+    color: var(--c-warning);
     border-radius: 10px;
     padding: 0.05rem 0.35rem;
     min-width: 1rem;
@@ -177,12 +177,12 @@
     cursor: pointer;
     font-family: inherit;
     text-align: left;
-    color: #92400e;
+    color: var(--c-warning);
     transition: background 0.12s;
   }
 
   .a11y-issue:not(:disabled):hover {
-    background: #fef3c7;
+    background: color-mix(in srgb, var(--c-warning), transparent 80%);
   }
 
   .a11y-issue:disabled {

--- a/packages/admin/src/lib/components/BlockEditorRegion.svelte
+++ b/packages/admin/src/lib/components/BlockEditorRegion.svelte
@@ -738,7 +738,7 @@
   .region-section {
     border: 1px solid var(--c-border, #e2e8f0);
     border-radius: var(--radius, 6px);
-    background: #fff;
+    background: var(--c-surface);
     transition: box-shadow 0.2s, border-color 0.2s;
   }
 
@@ -856,7 +856,7 @@
     height: 10px;
     border-radius: 50%;
     background: var(--c-primary, #2563eb);
-    border: 2px solid #fff;
+    border: 2px solid var(--c-surface);
     box-shadow: 0 0 0 1px var(--c-primary, #2563eb);
   }
 
@@ -868,17 +868,17 @@
   .block-card {
     border: 1px solid var(--c-border, #e2e8f0);
     border-radius: var(--radius, 6px);
-    background: #fff;
+    background: var(--c-surface);
     transition: border-color 0.15s, box-shadow 0.15s, opacity 0.15s;
     overflow: hidden;
   }
 
   .block-card:hover {
-    border-color: #cbd5e1;
+    border-color: var(--c-border);
   }
 
   .block-card.is-expanded {
-    border-color: #cbd5e1;
+    border-color: var(--c-border);
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
   }
 
@@ -888,8 +888,8 @@
   }
 
   @keyframes flash-drop {
-    0% { background: #dbeafe; border-color: var(--c-primary, #2563eb); box-shadow: 0 0 0 2px color-mix(in srgb, var(--c-primary, #2563eb) 20%, transparent); }
-    100% { background: #fff; border-color: var(--c-border, #e2e8f0); box-shadow: none; }
+    0% { background: color-mix(in srgb, var(--c-accent), transparent 80%); border-color: var(--c-primary, #2563eb); box-shadow: 0 0 0 2px color-mix(in srgb, var(--c-primary, #2563eb) 20%, transparent); }
+    100% { background: var(--c-surface); border-color: var(--c-border, #e2e8f0); box-shadow: none; }
   }
 
   .block-card.just-dropped {
@@ -920,7 +920,7 @@
     width: 28px;
     flex-shrink: 0;
     cursor: grab;
-    color: #cbd5e1;
+    color: var(--c-border);
     font-size: 1.1rem;
     user-select: none;
     align-self: stretch;
@@ -928,7 +928,7 @@
   }
 
   .block-drag-handle:hover {
-    color: #64748b;
+    color: var(--c-text-light);
     background: var(--c-bg-alt, #f8fafc);
   }
 
@@ -989,8 +989,8 @@
     font-weight: 600;
     padding: 0.1rem 0.35rem;
     border-radius: 3px;
-    background: #dbeafe;
-    color: #2563eb;
+    background: color-mix(in srgb, var(--c-accent), transparent 80%);
+    color: var(--c-accent);
     flex-shrink: 0;
     text-transform: uppercase;
     letter-spacing: 0.03em;
@@ -1040,12 +1040,12 @@
 
   .block-action-btn:hover {
     color: var(--c-accent, #3182ce);
-    background: rgba(49, 130, 206, 0.06);
+    background: color-mix(in srgb, var(--c-accent), transparent 94%);
   }
 
   .block-action-btn.block-action-danger:hover {
-    color: #ef4444;
-    background: #fef2f2;
+    color: var(--c-danger);
+    background: color-mix(in srgb, var(--c-danger), transparent 90%);
   }
 
   /* Inline icon next to block type badge */
@@ -1099,7 +1099,7 @@
 
   .picker-item:hover {
     border-color: var(--c-accent, #3182ce);
-    background: rgba(49, 130, 206, 0.04);
+    background: color-mix(in srgb, var(--c-accent), transparent 96%);
     transform: translateY(-1px);
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
   }
@@ -1117,7 +1117,7 @@
   }
 
   .picker-item:hover .picker-icon {
-    background: rgba(49, 130, 206, 0.1);
+    background: color-mix(in srgb, var(--c-accent), transparent 90%);
     color: var(--c-accent, #3182ce);
   }
 
@@ -1154,7 +1154,7 @@
 
   .move-region-option:hover {
     border-color: var(--c-accent, #3182ce);
-    background: rgba(49, 130, 206, 0.04);
+    background: color-mix(in srgb, var(--c-accent), transparent 96%);
   }
 
   .block-card-body {
@@ -1170,6 +1170,6 @@
 
   @keyframes a11y-flash-pulse {
     0%, 100% { outline: 2px solid transparent; background-color: transparent; }
-    50% { outline: 2px solid #f59e0b; background-color: rgba(245, 158, 11, 0.15); }
+    50% { outline: 2px solid var(--c-warning); background-color: color-mix(in srgb, var(--c-warning), transparent 85%); }
   }
 </style>

--- a/packages/admin/src/lib/components/GlobalSearch.svelte
+++ b/packages/admin/src/lib/components/GlobalSearch.svelte
@@ -219,7 +219,7 @@
 
   .search-input-wrapper:focus-within {
     border-color: var(--c-primary, #3182ce);
-    box-shadow: 0 0 0 3px rgba(49, 130, 206, 0.15);
+    box-shadow: 0 0 0 3px var(--c-focus-ring);
   }
 
   .search-input-wrapper input {

--- a/packages/admin/src/lib/components/MediaPicker.svelte
+++ b/packages/admin/src/lib/components/MediaPicker.svelte
@@ -441,7 +441,7 @@
 
   .upload-zone.drag-over {
     border-color: var(--c-primary, #2563eb);
-    background: #eff6ff;
+    background: color-mix(in srgb, var(--c-accent), transparent 90%);
     color: var(--c-primary, #2563eb);
   }
 
@@ -496,7 +496,7 @@
     padding: 0.4rem;
     border: 2px solid var(--c-border, #e2e8f0);
     border-radius: var(--radius, 6px);
-    background: #fff;
+    background: var(--c-surface);
     cursor: pointer;
     transition: border-color 0.15s, box-shadow 0.15s;
   }
@@ -562,7 +562,7 @@
     gap: 0.25rem;
     font-size: 0.7rem;
     font-weight: 500;
-    color: #d69e2e;
+    color: var(--c-warning);
     margin-bottom: 0.2rem;
   }
 
@@ -573,8 +573,8 @@
     width: 8px;
     height: 8px;
     border-radius: 50%;
-    background: #d69e2e;
-    border: 1.5px solid white;
-    box-shadow: 0 0 0 1px rgba(214, 158, 46, 0.3);
+    background: var(--c-warning);
+    border: 1.5px solid var(--c-surface);
+    box-shadow: 0 0 0 1px color-mix(in srgb, var(--c-warning), transparent 70%);
   }
 </style>

--- a/packages/admin/src/lib/components/PageEditorSidebar.svelte
+++ b/packages/admin/src/lib/components/PageEditorSidebar.svelte
@@ -449,15 +449,15 @@
   }
 
   .char-good {
-    color: #16a34a;
+    color: var(--c-success);
   }
 
   .char-warn {
-    color: #d97706;
+    color: var(--c-warning);
   }
 
   .char-bad {
-    color: #dc2626;
+    color: var(--c-danger);
   }
 
   .seo-previews {
@@ -483,7 +483,7 @@
   }
 
   .seo-preview-toggle:hover {
-    background: rgba(49, 130, 206, 0.04);
+    background: color-mix(in srgb, var(--c-accent), transparent 96%);
     border-color: var(--c-accent, #3182ce);
   }
 

--- a/packages/admin/src/lib/components/PresenceIndicator.svelte
+++ b/packages/admin/src/lib/components/PresenceIndicator.svelte
@@ -79,8 +79,8 @@
     align-items: center;
     gap: 0.5rem;
     padding: 0.35rem 0.75rem;
-    background: #fefce8;
-    border: 1px solid #fde68a;
+    background: color-mix(in srgb, var(--c-warning), transparent 85%);
+    border: 1px solid color-mix(in srgb, var(--c-warning), transparent 60%);
     border-radius: var(--radius, 6px);
     font-size: 0.78rem;
   }
@@ -89,7 +89,7 @@
     width: 8px;
     height: 8px;
     border-radius: 50%;
-    background: #22c55e;
+    background: var(--c-success);
     flex-shrink: 0;
     animation: pulse-dot 2s ease-in-out infinite;
   }
@@ -111,10 +111,10 @@
     width: 24px;
     height: 24px;
     border-radius: 50%;
-    color: #fff;
+    color: white;
     font-size: 0.6rem;
     font-weight: 700;
-    border: 2px solid #fefce8;
+    border: 2px solid var(--c-surface);
     margin-right: -6px;
   }
 
@@ -123,7 +123,7 @@
   }
 
   .presence-text {
-    color: #92400e;
+    color: var(--c-warning);
     font-weight: 500;
     white-space: nowrap;
   }

--- a/packages/admin/src/lib/components/PreviewPanel.svelte
+++ b/packages/admin/src/lib/components/PreviewPanel.svelte
@@ -226,7 +226,7 @@
     flex: 1;
     position: relative;
     overflow: hidden;
-    background: #e5e7eb;
+    background: var(--c-bg-subtle);
   }
   .preview-loading {
     position: absolute;
@@ -242,7 +242,7 @@
     width: 100%;
     height: 100%;
     border: none;
-    background: white;
+    background: var(--c-surface);
     display: block;
     transition: width 0.3s ease;
   }

--- a/packages/admin/src/lib/components/RepeaterEditor.svelte
+++ b/packages/admin/src/lib/components/RepeaterEditor.svelte
@@ -155,7 +155,7 @@
   .repeater-item {
     border: 1px solid var(--c-border, #e2e8f0);
     border-radius: var(--radius, 6px);
-    background: #fff;
+    background: var(--c-surface);
     overflow: hidden;
   }
 
@@ -207,7 +207,7 @@
     justify-content: center;
     border: 1px solid var(--c-border, #e2e8f0);
     border-radius: 4px;
-    background: #fff;
+    background: var(--c-surface);
     color: var(--c-text-light, #94a3b8);
     font-size: 0.6rem;
     cursor: pointer;
@@ -215,7 +215,7 @@
   }
 
   .repeater-btn:hover:not(:disabled) {
-    border-color: #cbd5e1;
+    border-color: var(--c-border);
     color: var(--c-text, #1e293b);
   }
 
@@ -225,9 +225,9 @@
   }
 
   .repeater-btn-remove:hover:not(:disabled) {
-    border-color: #fca5a5;
-    color: #ef4444;
-    background: #fef2f2;
+    border-color: var(--c-danger);
+    color: var(--c-danger);
+    background: color-mix(in srgb, var(--c-danger), transparent 90%);
   }
 
   .repeater-item-fields {

--- a/packages/admin/src/lib/components/RepeaterEditor.svelte
+++ b/packages/admin/src/lib/components/RepeaterEditor.svelte
@@ -93,7 +93,7 @@
       <div class="repeater-item-fields">
         {#each subFields as sf}
           <div class="form-group">
-            <label style="font-size: 0.78rem;">{sf.label || sf.name}{#if sf.required} <span style="color: #ef4444;">*</span>{/if}</label>
+            <label style="font-size: 0.78rem;">{sf.label || sf.name}{#if sf.required} <span style="color: var(--c-danger);">*</span>{/if}</label>
             {#if sf.type === 'richtext'}
               <RichTextEditor content={item[sf.name] || ''} onUpdate={(json) => updateSubField(i, sf.name, json)} />
             {:else if sf.type === 'media'}

--- a/packages/admin/src/lib/components/RevisionDiff.svelte
+++ b/packages/admin/src/lib/components/RevisionDiff.svelte
@@ -146,12 +146,12 @@
     word-break: break-all;
   }
   .diff-changed {
-    background: #fff3cd;
+    background: color-mix(in srgb, var(--c-warning), transparent 80%);
   }
   .diff-changed .diff-val:first-of-type {
-    color: #b91c1c;
+    color: var(--c-danger);
   }
   .diff-changed .diff-val:last-child {
-    color: #15803d;
+    color: var(--c-success);
   }
 </style>

--- a/packages/admin/src/lib/components/RichTextEditor.svelte
+++ b/packages/admin/src/lib/components/RichTextEditor.svelte
@@ -598,28 +598,28 @@
   .rte-btn.active { background: var(--c-accent, #3182ce); color: #fff; border-color: var(--c-accent, #3182ce); }
   .rte-divider { display: inline-block; width: 1px; height: 20px; background: var(--c-border, #e2e8f0); margin: 0 3px; }
 
-  .rte-table-toolbar { display: flex; flex-wrap: wrap; align-items: center; gap: 3px; padding: 4px 8px; background: #eff6ff; border-bottom: 1px solid #bfdbfe; }
-  .rte-table-label { font-size: 0.7rem; font-weight: 600; color: #2563eb; margin-right: 4px; }
-  .rte-image-toolbar { display: flex; flex-wrap: wrap; align-items: center; gap: 3px; padding: 4px 8px; background: #f0fdf4; border-bottom: 1px solid #bbf7d0; }
-  .rte-image-label { font-size: 0.7rem; font-weight: 600; color: #16a34a; margin-right: 2px; margin-left: 2px; }
-  .rte-image-caption-bar { padding: 4px 10px; background: #f0fdf4; border-bottom: 1px solid #bbf7d0; font-size: 0.72rem; color: #166534; }
+  .rte-table-toolbar { display: flex; flex-wrap: wrap; align-items: center; gap: 3px; padding: 4px 8px; background: color-mix(in srgb, var(--c-accent), transparent 90%); border-bottom: 1px solid color-mix(in srgb, var(--c-accent), transparent 60%); }
+  .rte-table-label { font-size: 0.7rem; font-weight: 600; color: var(--c-accent); margin-right: 4px; }
+  .rte-image-toolbar { display: flex; flex-wrap: wrap; align-items: center; gap: 3px; padding: 4px 8px; background: color-mix(in srgb, var(--c-success), transparent 90%); border-bottom: 1px solid color-mix(in srgb, var(--c-success), transparent 60%); }
+  .rte-image-label { font-size: 0.7rem; font-weight: 600; color: var(--c-success); margin-right: 2px; margin-left: 2px; }
+  .rte-image-caption-bar { padding: 4px 10px; background: color-mix(in srgb, var(--c-success), transparent 90%); border-bottom: 1px solid color-mix(in srgb, var(--c-success), transparent 60%); font-size: 0.72rem; color: var(--c-success); }
 
-  .rte-btn-sm { display: inline-flex; align-items: center; justify-content: center; height: 24px; padding: 0 6px; font-size: 0.68rem; font-weight: 500; font-family: var(--font, system-ui); color: var(--c-text, #2d3748); background: #fff; border: 1px solid #ddd; border-radius: 3px; cursor: pointer; transition: background 0.12s; }
-  .rte-btn-sm:hover { background: #f1f5f9; }
-  .rte-btn-sm.active { background: #16a34a; color: #fff; border-color: #16a34a; }
-  .rte-btn-danger { color: #dc2626; }
-  .rte-btn-danger:hover { background: #fef2f2; border-color: #fca5a5; }
+  .rte-btn-sm { display: inline-flex; align-items: center; justify-content: center; height: 24px; padding: 0 6px; font-size: 0.68rem; font-weight: 500; font-family: var(--font, system-ui); color: var(--c-text, #2d3748); background: var(--c-surface); border: 1px solid var(--c-border); border-radius: 3px; cursor: pointer; transition: background 0.12s; }
+  .rte-btn-sm:hover { background: var(--c-bg-subtle); }
+  .rte-btn-sm.active { background: var(--c-success); color: white; border-color: var(--c-success); }
+  .rte-btn-danger { color: var(--c-danger); }
+  .rte-btn-danger:hover { background: color-mix(in srgb, var(--c-danger), transparent 90%); border-color: var(--c-danger); }
 
-  .rte-heading-warn { display: flex; flex-wrap: wrap; gap: 0.5rem; padding: 4px 10px; background: #fef3c7; border-bottom: 1px solid #fcd34d; font-size: 0.72rem; color: #92400e; }
+  .rte-heading-warn { display: flex; flex-wrap: wrap; gap: 0.5rem; padding: 4px 10px; background: color-mix(in srgb, var(--c-warning), transparent 80%); border-bottom: 1px solid color-mix(in srgb, var(--c-warning), transparent 50%); font-size: 0.72rem; color: var(--c-warning); }
   .rte-heading-warn-item::before { content: '\26A0\FE0F '; }
 
   .rte-editor-wrap { position: relative; }
   .rte-editor { min-height: 200px; padding: 12px 16px; font-family: var(--font, system-ui); font-size: 0.9rem; line-height: 1.6; color: var(--c-text, #2d3748); }
   .rte-editor.rte-hidden { display: none; }
-  .rte-source { display: block; width: 100%; min-height: 300px; padding: 12px 16px; border: none; outline: none; resize: vertical; font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace; font-size: 0.82rem; line-height: 1.6; color: var(--c-text, #2d3748); background: #fefce8; box-sizing: border-box; tab-size: 2; }
+  .rte-source { display: block; width: 100%; min-height: 300px; padding: 12px 16px; border: none; outline: none; resize: vertical; font-family: 'SF Mono', 'Fira Code', 'Consolas', monospace; font-size: 0.82rem; line-height: 1.6; color: var(--c-text, #2d3748); background: color-mix(in srgb, var(--c-warning), transparent 90%); box-sizing: border-box; tab-size: 2; }
 
   .slash-menu-container { position: absolute; z-index: 50; }
-  .slash-menu { display: flex; flex-direction: column; background: #fff; border: 1px solid var(--c-border, #e2e8f0); border-radius: var(--radius, 6px); box-shadow: 0 4px 16px rgba(0,0,0,0.12); max-height: 240px; overflow-y: auto; min-width: 220px; padding: 4px; }
+  .slash-menu { display: flex; flex-direction: column; background: var(--c-surface); border: 1px solid var(--c-border, #e2e8f0); border-radius: var(--radius, 6px); box-shadow: 0 4px 16px rgba(0,0,0,0.12); max-height: 240px; overflow-y: auto; min-width: 220px; padding: 4px; }
   .slash-menu-item { display: flex; flex-direction: column; gap: 1px; padding: 0.4rem 0.6rem; border: none; background: transparent; cursor: pointer; text-align: left; border-radius: 4px; font-family: inherit; transition: background 0.1s; }
   .slash-menu-item:hover, .slash-menu-item.selected { background: var(--c-bg-alt, #f1f5f9); }
   .slash-menu-label { font-size: 0.82rem; font-weight: 600; color: var(--c-text, #1e293b); }
@@ -640,7 +640,7 @@
   .link-label { display: block; font-size: 0.8rem; font-weight: 600; margin-bottom: 0.3rem; color: var(--c-text, #1e293b); }
   .link-label-spaced { margin-top: 0.75rem; }
   .link-input { width: 100%; padding: 0.5rem 0.75rem; border: 1px solid var(--c-border, #e2e8f0); border-radius: var(--radius, 6px); font-size: 0.85rem; font-family: inherit; color: var(--c-text, #1e293b); background: var(--c-surface, #fff); box-sizing: border-box; }
-  .link-input:focus { outline: none; border-color: var(--c-accent, #3182ce); box-shadow: 0 0 0 2px rgba(49,130,206,0.15); }
+  .link-input:focus { outline: none; border-color: var(--c-accent, #3182ce); box-shadow: 0 0 0 2px var(--c-focus-ring); }
   .link-checkbox-label { display: flex; align-items: center; gap: 0.4rem; margin-top: 0.75rem; font-size: 0.82rem; color: var(--c-text, #1e293b); cursor: pointer; user-select: none; }
   .link-checkbox-label input[type="checkbox"] { accent-color: var(--c-accent, #3182ce); width: 15px; height: 15px; cursor: pointer; }
   .link-footer { display: flex; align-items: center; gap: 0.5rem; padding: 0.75rem 1.25rem; border-top: 1px solid var(--c-border, #e2e8f0); }
@@ -669,5 +669,5 @@
   .rte-editor :global(.ProseMirror table) { border-collapse: collapse; width: 100%; margin: 0.5em 0; }
   .rte-editor :global(.ProseMirror th), .rte-editor :global(.ProseMirror td) { border: 1px solid var(--c-border, #e2e8f0); padding: 0.4em 0.6em; text-align: left; vertical-align: top; }
   .rte-editor :global(.ProseMirror th) { background: var(--c-bg, #f7f8fa); font-weight: 600; }
-  .rte-editor :global(.ProseMirror-dropcursor) { border-color: #2563eb; }
+  .rte-editor :global(.ProseMirror-dropcursor) { border-color: var(--c-accent); }
 </style>

--- a/packages/admin/src/lib/components/SerpPreview.svelte
+++ b/packages/admin/src/lib/components/SerpPreview.svelte
@@ -36,7 +36,7 @@
 
 <style>
   .serp-preview {
-    background: #fff;
+    background: var(--c-surface);
     border: 1px solid var(--c-border, #e2e8f0);
     border-radius: var(--radius, 6px);
     padding: 0.75rem;
@@ -46,7 +46,7 @@
   .serp-title {
     font-size: 1.1rem;
     line-height: 1.3;
-    color: #1a0dab;
+    color: var(--c-accent);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -59,7 +59,7 @@
 
   .serp-url {
     font-size: 0.8rem;
-    color: #006621;
+    color: var(--c-success);
     margin: 0.15rem 0;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -69,7 +69,7 @@
   .serp-desc {
     font-size: 0.82rem;
     line-height: 1.5;
-    color: #545454;
+    color: var(--c-text-light);
     display: -webkit-box;
     -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;
@@ -78,6 +78,6 @@
 
   .serp-desc-missing {
     font-style: italic;
-    color: #999;
+    color: var(--c-text-light);
   }
 </style>

--- a/packages/admin/src/lib/components/SlashCommandMenu.svelte
+++ b/packages/admin/src/lib/components/SlashCommandMenu.svelte
@@ -30,7 +30,7 @@
   .slash-menu {
     display: flex;
     flex-direction: column;
-    background: #fff;
+    background: var(--c-surface);
     border: 1px solid var(--c-border, #e2e8f0);
     border-radius: var(--radius, 6px);
     box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);

--- a/packages/admin/src/lib/components/SocialPreview.svelte
+++ b/packages/admin/src/lib/components/SocialPreview.svelte
@@ -48,14 +48,14 @@
     border: 1px solid var(--c-border, #e2e8f0);
     border-radius: var(--radius, 6px);
     overflow: hidden;
-    background: #f0f2f5;
+    background: var(--c-bg-subtle);
   }
 
   .og-image {
     width: 100%;
     aspect-ratio: 1.91 / 1;
     overflow: hidden;
-    background: #e4e6eb;
+    background: var(--c-bg-subtle);
   }
 
   .og-image img {
@@ -70,18 +70,18 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    color: #8a8d91;
+    color: var(--c-text-light);
     font-size: 0.8rem;
   }
 
   .og-body {
     padding: 0.6rem 0.75rem;
-    background: #f0f2f5;
+    background: var(--c-bg-subtle);
   }
 
   .og-domain {
     font-size: 0.7rem;
-    color: #606770;
+    color: var(--c-text-light);
     text-transform: uppercase;
     letter-spacing: 0.02em;
   }
@@ -89,7 +89,7 @@
   .og-title {
     font-size: 0.9rem;
     font-weight: 600;
-    color: #1d2129;
+    color: var(--c-text);
     line-height: 1.3;
     margin-top: 0.15rem;
     overflow: hidden;
@@ -99,7 +99,7 @@
 
   .og-desc {
     font-size: 0.78rem;
-    color: #606770;
+    color: var(--c-text-light);
     line-height: 1.4;
     margin-top: 0.1rem;
     overflow: hidden;

--- a/packages/admin/src/lib/components/SortableList.svelte
+++ b/packages/admin/src/lib/components/SortableList.svelte
@@ -95,7 +95,7 @@
     align-items: stretch;
     border: 1px solid var(--c-border, #e2e8f0);
     border-radius: var(--radius, 6px);
-    background: #fff;
+    background: var(--c-surface);
     transition: border-color 0.15s, background 0.15s, opacity 0.15s;
   }
 
@@ -105,7 +105,7 @@
 
   .sortable-item.drag-over {
     border-color: var(--c-primary, #2563eb);
-    background: #eff6ff;
+    background: color-mix(in srgb, var(--c-accent), transparent 90%);
     box-shadow: 0 0 0 1px var(--c-primary, #2563eb);
   }
 
@@ -116,7 +116,7 @@
     width: 2rem;
     flex-shrink: 0;
     cursor: grab;
-    color: #cbd5e1;
+    color: var(--c-border);
     font-size: 1.2rem;
     user-select: none;
     border-right: 1px solid var(--c-border, #e2e8f0);
@@ -124,7 +124,7 @@
   }
 
   .drag-handle:hover {
-    color: #64748b;
+    color: var(--c-text-light);
     background: var(--c-bg-alt, #f8fafc);
   }
 

--- a/packages/admin/src/lib/components/TaxonomyPicker.svelte
+++ b/packages/admin/src/lib/components/TaxonomyPicker.svelte
@@ -364,7 +364,7 @@
 
   .tag-input:focus {
     border-color: var(--c-accent, #3182ce);
-    box-shadow: 0 0 0 2px rgba(49, 130, 206, 0.15);
+    box-shadow: 0 0 0 2px var(--c-focus-ring);
   }
 
   .dropdown {

--- a/packages/admin/src/lib/components/ToastContainer.svelte
+++ b/packages/admin/src/lib/components/ToastContainer.svelte
@@ -48,18 +48,21 @@
   }
 
   .toast-success {
-    background: #22543d;
-    color: #c6f6d5;
+    background: var(--c-sidebar);
+    color: var(--c-success);
+    border: 1px solid color-mix(in srgb, var(--c-success), transparent 70%);
   }
 
   .toast-error {
-    background: #9b2c2c;
-    color: #fed7d7;
+    background: var(--c-sidebar);
+    color: var(--c-danger);
+    border: 1px solid color-mix(in srgb, var(--c-danger), transparent 70%);
   }
 
   .toast-info {
-    background: var(--c-primary);
-    color: #bee3f8;
+    background: var(--c-sidebar);
+    color: var(--c-accent);
+    border: 1px solid color-mix(in srgb, var(--c-accent), transparent 70%);
   }
 
   .toast-icon {

--- a/packages/admin/src/lib/theme.svelte.ts
+++ b/packages/admin/src/lib/theme.svelte.ts
@@ -1,0 +1,55 @@
+type Theme = 'light' | 'dark' | 'system';
+
+const STORAGE_KEY = 'wolly_theme';
+
+let theme = $state<Theme>(loadTheme());
+let resolved = $state<'light' | 'dark'>(resolveTheme(theme));
+
+function loadTheme(): Theme {
+  if (typeof window === 'undefined') return 'system';
+  return (localStorage.getItem(STORAGE_KEY) as Theme) || 'system';
+}
+
+function resolveTheme(t: Theme): 'light' | 'dark' {
+  if (t !== 'system') return t;
+  if (typeof window === 'undefined') return 'light';
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+function apply(r: 'light' | 'dark') {
+  if (typeof document === 'undefined') return;
+  document.documentElement.dataset.theme = r;
+}
+
+// Listen for OS preference changes
+if (typeof window !== 'undefined') {
+  window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
+    if (theme === 'system') {
+      resolved = resolveTheme('system');
+      apply(resolved);
+    }
+  });
+  // Apply on load
+  apply(resolved);
+}
+
+export function getTheme() {
+  return {
+    get preference() { return theme; },
+    get resolved() { return resolved; },
+    get isDark() { return resolved === 'dark'; },
+
+    set(t: Theme) {
+      theme = t;
+      resolved = resolveTheme(t);
+      localStorage.setItem(STORAGE_KEY, t);
+      apply(resolved);
+    },
+
+    cycle() {
+      const order: Theme[] = ['light', 'dark', 'system'];
+      const next = order[(order.indexOf(theme) + 1) % order.length];
+      this.set(next);
+    },
+  };
+}

--- a/packages/admin/src/routes/+layout.svelte
+++ b/packages/admin/src/routes/+layout.svelte
@@ -169,7 +169,15 @@
     <aside class="sidebar" aria-label="Admin navigation">
       <div class="sidebar-header">
         <a href="{base}/" class="logo" aria-label="{brandName} Dashboard">
-          <span class="logo-icon" aria-hidden="true">{brandName[0].toUpperCase()}</span>
+          <span class="logo-icon" aria-hidden="true">
+            <svg width="28" height="28" viewBox="0 0 512 512" fill="none">
+              <rect width="512" height="512" rx="128" fill="#10B981"/>
+              <rect x="110" y="110" width="292" height="55" rx="18" fill="white"/>
+              <rect x="110" y="195" width="180" height="207" rx="18" fill="white"/>
+              <rect x="320" y="195" width="82" height="91" rx="18" fill="white"/>
+              <rect x="320" y="311" width="82" height="91" rx="18" fill="white"/>
+            </svg>
+          </span>
           <span class="logo-text">{brandName}</span>
         </a>
       </div>

--- a/packages/admin/src/routes/+layout.svelte
+++ b/packages/admin/src/routes/+layout.svelte
@@ -12,8 +12,12 @@
     LayoutDashboard, FileText, Blocks, Image, Menu, Tags,
     CornerDownRight, ClipboardList, Square, Users, Settings,
     Webhook, KeyRound, ScrollText, Code, Shield,
+    Sun, Moon, Monitor,
   } from 'lucide-svelte';
+  import { getTheme } from '$lib/theme.svelte.js';
   import '../app.css';
+
+  const theme = getTheme();
 
   let { children } = $props();
   const auth = getAuth();
@@ -197,6 +201,20 @@
           <span class="user-role">{auth.user.role}</span>
         </div>
         <div class="sidebar-footer-actions">
+          <button
+            class="btn-theme-toggle"
+            onclick={() => theme.cycle()}
+            title="{theme.preference === 'light' ? 'Light' : theme.preference === 'dark' ? 'Dark' : 'System'} theme"
+            aria-label="Toggle theme"
+          >
+            {#if theme.preference === 'light'}
+              <Sun size={14} />
+            {:else if theme.preference === 'dark'}
+              <Moon size={14} />
+            {:else}
+              <Monitor size={14} />
+            {/if}
+          </button>
           <button class="btn-shortcut-hint" onclick={() => showShortcuts = true} title="Keyboard shortcuts">
             <kbd>?</kbd>
           </button>

--- a/packages/admin/src/routes/+layout.svelte
+++ b/packages/admin/src/routes/+layout.svelte
@@ -158,11 +158,11 @@
 <svelte:window onkeydown={handleGlobalKeydown} />
 
 {#if !auth.loaded && !needsSetup}
-  <div class="loading">Loading...</div>
+  <div class="loading"><div class="loading-spinner"></div></div>
 {:else if isPublicPage || needsSetup}
   {@render children()}
 {:else if !auth.user}
-  <div class="loading">Redirecting...</div>
+  <div class="loading"><div class="loading-spinner"></div></div>
 {:else}
   <a href="#main-content" class="skip-link">Skip to main content</a>
   <div class="admin-layout">

--- a/packages/admin/src/routes/+page.svelte
+++ b/packages/admin/src/routes/+page.svelte
@@ -73,11 +73,20 @@
       <div class="stat-label">Users</div>
     </div>
   </div>
+{:else if !error}
+  <div class="stats-grid">
+    {#each Array(7) as _}
+      <div class="stat-card">
+        <div class="skeleton skeleton-title" style="width: 50%;"></div>
+        <div class="skeleton skeleton-text" style="width: 70%;"></div>
+      </div>
+    {/each}
+  </div>
 {/if}
 
 <div class="card">
   <h2 style="margin-bottom: 1rem; font-size: 1.1rem;">Recently Updated Pages</h2>
-  {#if recentPages.length > 0}
+  {#if stats && recentPages.length > 0}
     <div class="table-wrap">
       <table>
         <thead>
@@ -102,8 +111,19 @@
         </tbody>
       </table>
     </div>
-  {:else}
-    <div class="empty-state"><p>No pages yet. Create your first page to get started.</p></div>
+  {:else if stats && recentPages.length === 0}
+    <div class="empty-state">
+      <div class="empty-state-icon"><FilePlus size={40} /></div>
+      <div class="empty-state-title">No pages yet</div>
+      <p>Create your first page to get started.</p>
+      <a href="{base}/pages" class="btn btn-primary" style="margin-top: 0.5rem;">Go to Pages</a>
+    </div>
+  {:else if !error}
+    <div>
+      {#each Array(5) as _}
+        <div class="skeleton skeleton-row" style="margin-bottom: 1px;"></div>
+      {/each}
+    </div>
   {/if}
 </div>
 

--- a/packages/admin/src/routes/+page.svelte
+++ b/packages/admin/src/routes/+page.svelte
@@ -6,13 +6,18 @@
 
   let stats = $state<any>(null);
   let recentPages = $state<any[]>([]);
+  let siteUrl = $state('');
   let error = $state('');
 
   onMount(async () => {
     try {
-      const res = await api.get<{ data: any }>('/dashboard');
-      stats = res.data.stats;
-      recentPages = res.data.recentPages;
+      const [dashRes, configRes] = await Promise.all([
+        api.get<{ data: any }>('/dashboard'),
+        api.get<{ data: any }>('/config'),
+      ]);
+      stats = dashRes.data.stats;
+      recentPages = dashRes.data.recentPages;
+      siteUrl = configRes.data.siteUrl || '';
     } catch (err: any) {
       error = err.message;
     }
@@ -36,10 +41,12 @@
     <span class="qa-icon"><Upload size={22} /></span>
     <span class="qa-label">Upload Media</span>
   </a>
-  <a href="http://localhost:4322" target="_blank" rel="noopener" class="quick-action-card" style="--qa-color: var(--c-warning, #d69e2e);">
-    <span class="qa-icon"><ExternalLink size={22} /></span>
-    <span class="qa-label">View Site</span>
-  </a>
+  {#if siteUrl}
+    <a href={siteUrl} target="_blank" rel="noopener" class="quick-action-card" style="--qa-color: var(--c-warning, #d69e2e);">
+      <span class="qa-icon"><ExternalLink size={22} /></span>
+      <span class="qa-label">View Site</span>
+    </a>
+  {/if}
 </div>
 
 {#if stats}

--- a/packages/admin/src/routes/account/+page.svelte
+++ b/packages/admin/src/routes/account/+page.svelte
@@ -413,15 +413,16 @@
   }
 
   .btn-danger {
-    background: #dc2626;
+    background: var(--c-danger);
     color: white;
     border: none;
     padding: 0.5rem 1rem;
-    border-radius: 4px;
+    border-radius: var(--radius);
     cursor: pointer;
+    transition: opacity var(--transition);
   }
 
   .btn-danger:hover {
-    background: #b91c1c;
+    opacity: 0.85;
   }
 </style>

--- a/packages/admin/src/routes/login/+page.svelte
+++ b/packages/admin/src/routes/login/+page.svelte
@@ -252,20 +252,20 @@
     gap: 0.5rem;
     width: 100%;
     padding: 0.6rem 1rem;
-    background: white;
-    color: #3c4043;
-    border: 1px solid #dadce0;
-    border-radius: 4px;
+    background: var(--c-surface);
+    color: var(--c-text);
+    border: 1px solid var(--c-border);
+    border-radius: var(--radius);
     font-size: 0.9rem;
     font-weight: 500;
     cursor: pointer;
     text-decoration: none;
-    transition: background 0.15s, box-shadow 0.15s;
+    transition: background var(--transition), box-shadow var(--transition);
   }
 
   .btn-google:hover {
-    background: #f8f9fa;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    background: var(--c-bg-subtle);
+    box-shadow: var(--shadow);
   }
 
   .google-icon {
@@ -290,7 +290,7 @@
   .btn-link {
     background: none;
     border: none;
-    color: var(--c-primary, #4f46e5);
+    color: var(--c-accent);
     cursor: pointer;
     font-size: 0.85rem;
     padding: 0;

--- a/packages/admin/src/routes/media/+page.svelte
+++ b/packages/admin/src/routes/media/+page.svelte
@@ -10,6 +10,7 @@
   let searchQuery = $state('');
   let searchDebounce: ReturnType<typeof setTimeout>;
   let error = $state('');
+  let loading = $state(true);
   let uploading = $state(false);
   let editItem = $state<any>(null);
   let newFolderName = $state('');
@@ -23,6 +24,7 @@
   const totalPages = $derived(Math.max(1, Math.ceil(total / pageSize)));
 
   async function load() {
+    loading = true;
     try {
       const params = new URLSearchParams();
       if (searchQuery) params.set('search', searchQuery);
@@ -36,7 +38,7 @@
       const res = await api.get<{ data: any[]; meta: { total: number } }>(`/media${qs ? '?' + qs : ''}`);
       items = res.data;
       total = res.meta.total;
-    } catch (err: any) { error = err.message; }
+    } catch (err: any) { error = err.message; } finally { loading = false; }
   }
 
   function goToPage(page: number) {
@@ -253,40 +255,51 @@
     </div>
 
     <div class="media-grid">
-      {#each items as item}
-        <div class="card media-card" onclick={() => editItem = { ...item }} role="button" tabindex="0" onkeydown={(e) => { if (e.key === 'Enter') editItem = { ...item }; }}>
-          <div class="media-thumb">
-            {#if item.mimeType?.startsWith('image/')}
-              <img src="/api/content/media/{item.id}/thumbnail" alt={item.altText || ''} />
-              {#if !item.altText}
-                <span class="alt-badge" title="Missing alt text">No alt text</span>
-              {/if}
-            {:else if item.mimeType?.startsWith('video/')}
-              <div class="media-file-icon">
-                <span class="icon">&#127916;</span>
-                <span class="ext">{item.mimeType.split('/')[1].toUpperCase()}</span>
-              </div>
-            {:else}
-              <div class="media-file-icon">
-                <span class="icon">&#128196;</span>
-                <span class="ext">{item.originalName?.split('.').pop()?.toUpperCase() || 'FILE'}</span>
-              </div>
-            {/if}
-          </div>
-          <div class="media-info">
-            <p class="media-title">{item.title || item.originalName}</p>
-            <p class="media-meta">{formatSize(item.size)}{item.folder ? ` \u00B7 ${item.folder}` : ''}</p>
-            <div class="media-actions">
-              <button class="btn btn-sm btn-outline" onclick={(e) => { e.stopPropagation(); editItem = { ...item }; }}>Edit</button>
-              <button class="btn btn-sm btn-danger" onclick={(e) => { e.stopPropagation(); deleteItem(item.id); }}>Delete</button>
+      {#if loading}
+        {#each Array(8) as _}
+          <div class="card media-card">
+            <div class="media-thumb"><div class="skeleton" style="width: 100%; height: 100%;"></div></div>
+            <div class="media-info">
+              <div class="skeleton skeleton-text" style="width: 80%;"></div>
+              <div class="skeleton skeleton-text" style="width: 50%;"></div>
             </div>
           </div>
-        </div>
-      {/each}
-      {#if items.length === 0}
+        {/each}
+      {:else if items.length === 0}
         <div class="media-empty">
-          <p>No media found{searchQuery ? ` matching "${searchQuery}"` : ''}.</p>
+          <p>No media found{searchQuery ? ` matching "${searchQuery}"` : ''}. Upload files to get started.</p>
         </div>
+      {:else}
+        {#each items as item}
+          <div class="card media-card" onclick={() => editItem = { ...item }} role="button" tabindex="0" onkeydown={(e) => { if (e.key === 'Enter') editItem = { ...item }; }}>
+            <div class="media-thumb">
+              {#if item.mimeType?.startsWith('image/')}
+                <img src="/api/content/media/{item.id}/thumbnail" alt={item.altText || ''} />
+                {#if !item.altText}
+                  <span class="alt-badge" title="Missing alt text">No alt text</span>
+                {/if}
+              {:else if item.mimeType?.startsWith('video/')}
+                <div class="media-file-icon">
+                  <span class="icon">&#127916;</span>
+                  <span class="ext">{item.mimeType.split('/')[1].toUpperCase()}</span>
+                </div>
+              {:else}
+                <div class="media-file-icon">
+                  <span class="icon">&#128196;</span>
+                  <span class="ext">{item.originalName?.split('.').pop()?.toUpperCase() || 'FILE'}</span>
+                </div>
+              {/if}
+            </div>
+            <div class="media-info">
+              <p class="media-title">{item.title || item.originalName}</p>
+              <p class="media-meta">{formatSize(item.size)}{item.folder ? ` \u00B7 ${item.folder}` : ''}</p>
+              <div class="media-actions">
+                <button class="btn btn-sm btn-outline" onclick={(e) => { e.stopPropagation(); editItem = { ...item }; }}>Edit</button>
+                <button class="btn btn-sm btn-danger" onclick={(e) => { e.stopPropagation(); deleteItem(item.id); }}>Delete</button>
+              </div>
+            </div>
+          </div>
+        {/each}
       {/if}
     </div>
 

--- a/packages/admin/src/routes/media/+page.svelte
+++ b/packages/admin/src/routes/media/+page.svelte
@@ -381,7 +381,7 @@
   .folder-item:hover { background: var(--c-bg); }
   .folder-item.active {
     background: var(--c-primary);
-    color: #fff;
+    color: white;
     font-weight: 500;
   }
 
@@ -450,7 +450,7 @@
     font-family: inherit;
     border: 1px solid var(--c-border, #e2e8f0);
     border-radius: var(--radius, 6px);
-    background: #fff;
+    background: var(--c-surface);
     color: var(--c-text, #2d3748);
     cursor: pointer;
     transition: all 0.12s;
@@ -464,7 +464,7 @@
   .pagination-btn.active {
     background: var(--c-accent, #3182ce);
     border-color: var(--c-accent, #3182ce);
-    color: #fff;
+    color: white;
   }
 
   .pagination-btn:disabled {
@@ -513,8 +513,8 @@
     font-size: 0.6rem;
     font-weight: 600;
     padding: 0.15rem 0.4rem;
-    background: #fbbf24;
-    color: #78350f;
+    background: var(--c-warning);
+    color: var(--c-surface);
     border-radius: 3px;
     line-height: 1;
   }

--- a/packages/admin/src/routes/media/+page.svelte
+++ b/packages/admin/src/routes/media/+page.svelte
@@ -380,7 +380,7 @@
   }
   .folder-item:hover { background: var(--c-bg); }
   .folder-item.active {
-    background: var(--c-primary);
+    background: var(--c-accent);
     color: white;
     font-weight: 500;
   }

--- a/packages/admin/src/routes/pages/+page.svelte
+++ b/packages/admin/src/routes/pages/+page.svelte
@@ -18,6 +18,7 @@
 
   let pages = $state<any[]>([]);
   let total = $state(0);
+  let loading = $state(true);
   let error = $state('');
   let search = $state('');
   let statusFilter = $state('');
@@ -39,6 +40,7 @@
   );
 
   async function load() {
+    loading = true;
     try {
       const params = new URLSearchParams();
       if (search) params.set('search', search);
@@ -53,6 +55,8 @@
       selected = new Set();
     } catch (err: any) {
       error = err.message;
+    } finally {
+      loading = false;
     }
   }
 
@@ -221,24 +225,47 @@
       </tr>
     </thead>
     <tbody>
-      {#each pages as page}
-        <tr style="--type-color: {getTypeColor(page.type || '')};">
-          <td><input type="checkbox" checked={selected.has(page.id)} onchange={() => toggleSelect(page.id)} aria-label={"Select page " + page.title} /></td>
-          <td class="td-title"><span class="type-bar"></span><a href="{base}/pages/{page.id}"><strong>{page.title}</strong></a></td>
-          <td class="mono" style="color: var(--c-text-light);">/{page.slug}</td>
-          <td>{page.typeName}</td>
-          <td><span class="badge badge-{page.status}">{page.status}</span></td>
-          <td>{new Date(page.meta.updated_at).toLocaleDateString()}</td>
-          <td style="text-align: right;">
-            <a href="{base}/pages/{page.id}" class="btn btn-sm btn-outline">Edit</a>
-            <button class="btn btn-sm btn-outline" onclick={() => duplicatePage(page.id)}>Duplicate</button>
-            {#if page.status !== 'archived'}
-              <button class="btn btn-sm btn-outline" onclick={() => archivePage(page.id)}>Archive</button>
-            {/if}
-            <button class="btn btn-sm btn-danger" onclick={() => deletePage(page.id)}>Delete</button>
+      {#if loading}
+        {#each Array(5) as _}
+          <tr>
+            <td><div class="skeleton" style="width: 16px; height: 16px; border-radius: 3px;"></div></td>
+            <td><div class="skeleton skeleton-text" style="width: 70%;"></div></td>
+            <td><div class="skeleton skeleton-text" style="width: 50%;"></div></td>
+            <td><div class="skeleton skeleton-text" style="width: 80%;"></div></td>
+            <td><div class="skeleton" style="width: 72px; height: 22px; border-radius: 999px;"></div></td>
+            <td><div class="skeleton skeleton-text" style="width: 60%;"></div></td>
+            <td></td>
+          </tr>
+        {/each}
+      {:else if pages.length === 0}
+        <tr>
+          <td colspan="7">
+            <div class="empty-state">
+              <div class="empty-state-title">No pages found</div>
+              <p>{search || statusFilter || typeFilter ? 'Try adjusting your filters.' : 'Create your first page to get started.'}</p>
+            </div>
           </td>
         </tr>
-      {/each}
+      {:else}
+        {#each pages as page}
+          <tr style="--type-color: {getTypeColor(page.type || '')};">
+            <td><input type="checkbox" checked={selected.has(page.id)} onchange={() => toggleSelect(page.id)} aria-label={"Select page " + page.title} /></td>
+            <td class="td-title"><span class="type-bar"></span><a href="{base}/pages/{page.id}"><strong>{page.title}</strong></a></td>
+            <td class="mono" style="color: var(--c-text-light);">/{page.slug}</td>
+            <td>{page.typeName}</td>
+            <td><span class="badge badge-{page.status}">{page.status}</span></td>
+            <td>{new Date(page.meta.updated_at).toLocaleDateString()}</td>
+            <td style="text-align: right;">
+              <a href="{base}/pages/{page.id}" class="btn btn-sm btn-outline">Edit</a>
+              <button class="btn btn-sm btn-outline" onclick={() => duplicatePage(page.id)}>Duplicate</button>
+              {#if page.status !== 'archived'}
+                <button class="btn btn-sm btn-outline" onclick={() => archivePage(page.id)}>Archive</button>
+              {/if}
+              <button class="btn btn-sm btn-danger" onclick={() => deletePage(page.id)}>Delete</button>
+            </td>
+          </tr>
+        {/each}
+      {/if}
     </tbody>
   </table>
 </div>

--- a/packages/admin/src/routes/pages/[id]/+page.svelte
+++ b/packages/admin/src/routes/pages/[id]/+page.svelte
@@ -545,9 +545,9 @@
     width: 180px;
     padding: 0.35rem 0.5rem;
     font-size: 0.8rem;
-    border: 1px solid var(--c-border, #e2e8f0);
-    border-radius: var(--radius, 6px);
-    background: var(--c-bg, #fff);
+    border: 1px solid var(--c-border);
+    border-radius: var(--radius);
+    background: var(--c-surface);
     color: var(--c-text);
     font-family: var(--font);
     outline: none;

--- a/packages/admin/src/routes/pages/[id]/+page.svelte
+++ b/packages/admin/src/routes/pages/[id]/+page.svelte
@@ -63,9 +63,9 @@
 
   const statusConfig = $derived.by(() => {
     switch (pageData?.status) {
-      case 'published': return { label: 'Published', color: '#38a169', icon: CheckCircle };
-      case 'archived': return { label: 'Archived', color: '#718096', icon: Archive };
-      default: return { label: 'Draft', color: '#d69e2e', icon: Circle };
+      case 'published': return { label: 'Published', color: 'var(--c-success)', icon: CheckCircle };
+      case 'archived': return { label: 'Archived', color: 'var(--c-text-light)', icon: Archive };
+      default: return { label: 'Draft', color: 'var(--c-warning)', icon: Circle };
     }
   });
 

--- a/packages/admin/src/routes/pages/[id]/+page.svelte
+++ b/packages/admin/src/routes/pages/[id]/+page.svelte
@@ -457,11 +457,11 @@
   }
 
   .page-title:hover {
-    background: rgba(0, 0, 0, 0.03);
+    background: var(--c-bg-subtle);
   }
 
   .page-title:focus {
-    background: rgba(0, 0, 0, 0.03);
+    background: var(--c-bg-subtle);
     border-bottom-color: var(--c-accent);
   }
 
@@ -500,7 +500,7 @@
 
   .slug-display:hover {
     color: var(--c-accent);
-    background: rgba(49, 130, 206, 0.06);
+    background: color-mix(in srgb, var(--c-accent), transparent 94%);
   }
 
   .slug-prefix {
@@ -570,7 +570,7 @@
   .dirty-dot {
     width: 7px;
     height: 7px;
-    background: #fbbf24;
+    background: var(--c-warning);
     border-radius: 50%;
     display: inline-block;
     margin-right: 0.15rem;

--- a/packages/admin/static/favicon.svg
+++ b/packages/admin/static/favicon.svg
@@ -1,0 +1,7 @@
+<svg width="32" height="32" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="512" height="512" rx="128" fill="#10B981"/>
+  <rect x="110" y="110" width="292" height="55" rx="18" fill="white"/>
+  <rect x="110" y="195" width="180" height="207" rx="18" fill="white"/>
+  <rect x="320" y="195" width="82" height="91" rx="18" fill="white"/>
+  <rect x="320" y="311" width="82" height="91" rx="18" fill="white"/>
+</svg>

--- a/packages/admin/static/logo.svg
+++ b/packages/admin/static/logo.svg
@@ -1,0 +1,7 @@
+<svg width="512" height="512" viewBox="0 0 512 512" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="512" height="512" rx="128" fill="#10B981"/>
+  <rect x="110" y="110" width="292" height="55" rx="18" fill="white"/>
+  <rect x="110" y="195" width="180" height="207" rx="18" fill="white"/>
+  <rect x="320" y="195" width="82" height="91" rx="18" fill="white"/>
+  <rect x="320" y="311" width="82" height="91" rx="18" fill="white"/>
+</svg>


### PR DESCRIPTION
## Summary

- Dark mode with light/dark/system toggle, OS preference detection, localStorage persistence, no-flash inline script
- Replaced all hardcoded hex colors across 20+ component files with CSS variables
- Loading skeleton shimmer on dashboard, pages list, and media grid
- Animated spinner replaces "Loading..." text
- WollyCMS block composition logo SVG in sidebar, favicon, and docs site
- View Site button reads from SITE_URL config (not hardcoded localhost)
- `color-scheme: dark` for native form controls
- Improved empty states with icons and contextual messages
- Border radius bumped to 8px, softer shadows, smooth transitions
- Admin UI documentation page added to docs.wollycms.com

## Test plan

- [ ] Theme toggle cycles light → dark → system, persists on refresh
- [ ] No white flash on dark mode page load
- [ ] All pages readable in both themes (no contrast issues)
- [ ] Skeletons show during loading on dashboard, pages, media
- [ ] Logo visible in sidebar and browser tab
- [ ] View Site links to correct URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)