### PR TITLE
feat: mobile-responsive admin UI

### DIFF
--- a/packages/admin/src/app.css
+++ b/packages/admin/src/app.css
@@ -786,7 +786,26 @@ select.form-control {
   gap: 0.25rem;
 }
 
-/* Responsive */
+/* Mobile header (hidden on desktop) */
+.mobile-header {
+  display: none;
+}
+
+.mobile-close-btn {
+  display: none;
+}
+
+.mobile-overlay {
+  display: none;
+}
+
+.mobile-brand {
+  font-size: 1rem;
+  font-weight: 600;
+  color: var(--c-text);
+}
+
+/* Responsive — Tablet (icon-only sidebar) */
 @media (max-width: 1024px) {
   .sidebar {
     width: 60px;
@@ -838,6 +857,147 @@ select.form-control {
   }
 
   .form-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Responsive — Mobile (slide-out sidebar) */
+@media (max-width: 768px) {
+  .mobile-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 52px;
+    padding: 0 0.75rem;
+    background: var(--c-surface);
+    border-bottom: 1px solid var(--c-border);
+    z-index: 90;
+  }
+
+  .mobile-menu-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    background: none;
+    border: 1px solid var(--c-border);
+    border-radius: var(--radius);
+    color: var(--c-text);
+    cursor: pointer;
+  }
+
+  .mobile-overlay {
+    display: block;
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: 150;
+  }
+
+  .sidebar {
+    width: var(--sidebar-w);
+    transform: translateX(-100%);
+    transition: transform 0.2s ease;
+    z-index: 200;
+  }
+
+  .sidebar.mobile-open {
+    transform: translateX(0);
+  }
+
+  /* Restore full sidebar styles on mobile (not icon-only) */
+  .sidebar.mobile-open .nav-label,
+  .sidebar.mobile-open .nav-section-label,
+  .sidebar.mobile-open .nav-badge,
+  .sidebar.mobile-open .logo-text,
+  .sidebar.mobile-open .user-info {
+    display: initial;
+  }
+
+  .sidebar.mobile-open .sidebar-header {
+    padding: 1.25rem 1rem;
+    justify-content: flex-start;
+  }
+
+  .sidebar.mobile-open .logo {
+    justify-content: flex-start;
+  }
+
+  .sidebar.mobile-open .nav-item {
+    justify-content: flex-start;
+    padding: 0.5rem 1rem;
+  }
+
+  .sidebar.mobile-open .nav-item:hover::after {
+    display: none;
+  }
+
+  .sidebar.mobile-open .sidebar-footer {
+    justify-content: space-between;
+  }
+
+  .mobile-close-btn {
+    display: flex;
+    position: absolute;
+    top: 0.75rem;
+    right: 0.75rem;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    background: none;
+    border: none;
+    color: rgba(255, 255, 255, 0.6);
+    cursor: pointer;
+    border-radius: var(--radius);
+  }
+
+  .mobile-close-btn:hover {
+    background: rgba(255, 255, 255, 0.1);
+    color: white;
+  }
+
+  .main-content {
+    margin-left: 0;
+    padding: 1rem;
+    padding-top: calc(52px + 1rem);
+  }
+
+  .main-header {
+    margin-bottom: 0.75rem;
+  }
+
+  .page-header {
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  .page-header h1 {
+    font-size: 1.25rem;
+  }
+
+  /* Tables scroll horizontally */
+  .table-wrap {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .table-wrap table {
+    min-width: 600px;
+  }
+
+  /* Stats grid: 2 columns on mobile */
+  .stats-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  /* Quick actions: stack on mobile */
+  .quick-actions {
     grid-template-columns: 1fr;
   }
 }

--- a/packages/admin/src/routes/+layout.svelte
+++ b/packages/admin/src/routes/+layout.svelte
@@ -12,7 +12,7 @@
     LayoutDashboard, FileText, Blocks, Image, Menu, Tags,
     CornerDownRight, ClipboardList, Square, Users, Settings,
     Webhook, KeyRound, ScrollText, Code, Shield,
-    Sun, Moon, Monitor,
+    Sun, Moon, Monitor, PanelLeft, X,
   } from 'lucide-svelte';
   import { getTheme } from '$lib/theme.svelte.js';
   import '../app.css';
@@ -26,6 +26,7 @@
   );
   let needsSetup = $state(false);
   let showShortcuts = $state(false);
+  let mobileNavOpen = $state(false);
   let navCounts = $state<Record<string, number>>({});
   let brandName = $state('WollyCMS');
 
@@ -165,8 +166,34 @@
   <div class="loading"><div class="loading-spinner"></div></div>
 {:else}
   <a href="#main-content" class="skip-link">Skip to main content</a>
+  <!-- Mobile header bar -->
+  <div class="mobile-header">
+    <button class="mobile-menu-btn" onclick={() => mobileNavOpen = true} aria-label="Open navigation">
+      <PanelLeft size={20} />
+    </button>
+    <a href="{base}/" class="logo" aria-label="{brandName} Dashboard">
+      <span class="logo-icon" aria-hidden="true">
+        <svg width="24" height="24" viewBox="0 0 512 512" fill="none">
+          <rect width="512" height="512" rx="128" fill="#10B981"/>
+          <rect x="110" y="110" width="292" height="55" rx="18" fill="white"/>
+          <rect x="110" y="195" width="180" height="207" rx="18" fill="white"/>
+          <rect x="320" y="195" width="82" height="91" rx="18" fill="white"/>
+          <rect x="320" y="311" width="82" height="91" rx="18" fill="white"/>
+        </svg>
+      </span>
+      <span class="mobile-brand">{brandName}</span>
+    </a>
+    <div style="width: 36px;"></div>
+  </div>
+  <!-- Mobile overlay -->
+  {#if mobileNavOpen}
+    <div class="mobile-overlay" onclick={() => mobileNavOpen = false} role="presentation"></div>
+  {/if}
   <div class="admin-layout">
-    <aside class="sidebar" aria-label="Admin navigation">
+    <aside class="sidebar" class:mobile-open={mobileNavOpen} aria-label="Admin navigation">
+      <button class="mobile-close-btn" onclick={() => mobileNavOpen = false} aria-label="Close navigation">
+        <X size={18} />
+      </button>
       <div class="sidebar-header">
         <a href="{base}/" class="logo" aria-label="{brandName} Dashboard">
           <span class="logo-icon" aria-hidden="true">
@@ -193,6 +220,7 @@
               class:active={page.url.pathname === `${base}${item.href}` || (page.url.pathname.startsWith(`${base}${item.href}/`) && item.href !== '/')}
               title={item.label}
               aria-current={page.url.pathname === `${base}${item.href}` ? 'page' : undefined}
+              onclick={() => mobileNavOpen = false}
             >
               <span class="nav-icon" aria-hidden="true"><item.icon size={18} /></span>
               <span class="nav-label">{item.label}</span>

--- a/packages/admin/src/routes/pages/[id]/+page.svelte
+++ b/packages/admin/src/routes/pages/[id]/+page.svelte
@@ -358,7 +358,7 @@
 
   <div class="editor-layout" class:with-preview={showPreview}>
     <div class="editor-main">
-      <div style="display: grid; grid-template-columns: 1fr 320px; gap: 1.5rem;">
+      <div class="editor-grid">
         <div>
           {#if contentType?.fieldsSchema?.length > 0}
             <div class="card" style="margin-bottom: 1.5rem;">
@@ -580,5 +580,22 @@
   @keyframes pulse-dot {
     0%, 100% { opacity: 1; }
     50% { opacity: 0.4; }
+  }
+
+  .editor-grid {
+    display: grid;
+    grid-template-columns: 1fr 320px;
+    gap: 1.5rem;
+  }
+
+  @media (max-width: 768px) {
+    .editor-grid {
+      grid-template-columns: 1fr;
+    }
+
+    .revision-note-input {
+      width: 120px;
+      font-size: 0.75rem;
+    }
   }
 </style>


### PR DESCRIPTION
## Summary

- Mobile header bar (< 768px) with hamburger menu toggle
- Sidebar slides out as overlay with full labels/badges, closes on nav or overlay tap
- Main content goes full-width on mobile with proper top padding
- Tables scroll horizontally instead of squishing
- Dashboard quick actions and stats grid adapt to small screens
- Page editor SEO sidebar stacks below content on mobile

Note: the page editor itself (rich text, block cards) is desktop-optimized — consistent with how Strapi, Payload, and Sanity handle it.

## Test plan

- [ ] Phone (< 768px): hamburger opens/closes sidebar, nav works, tables scroll
- [ ] Tablet (768-1024px): icon-only sidebar unchanged
- [ ] Desktop (> 1024px): full sidebar unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)