### PR TITLE
feat: i18n / localization support

### DIFF
--- a/apps/docs/astro.config.mjs
+++ b/apps/docs/astro.config.mjs
@@ -54,6 +54,7 @@ export default defineConfig({
 						{ label: 'API Keys', slug: 'concepts/api-keys' },
 						{ label: 'Webhooks', slug: 'concepts/webhooks' },
 						{ label: 'Tracking Scripts', slug: 'concepts/tracking' },
+						{ label: 'Localization (i18n)', slug: 'concepts/i18n' },
 						{ label: 'Admin UI', slug: 'concepts/admin-ui' },
 						{ label: 'Block Type Recipes', slug: 'concepts/block-recipes' },
 					],

--- a/apps/docs/src/content/docs/concepts/i18n.md
+++ b/apps/docs/src/content/docs/concepts/i18n.md
@@ -1,0 +1,154 @@
+---
+title: Localization (i18n)
+description: Serve content in multiple languages with page-level translations, locale filtering, and language switcher support.
+---
+
+WollyCMS supports multi-language content through page-level localization. Each locale gets its own page with its own content, linked together by a translation group. This gives editors full control over each language version while keeping translations connected.
+
+## How it works
+
+- Each page has a `locale` field (e.g., `en`, `es`, `fr`) set at creation time
+- Translations of the same page share a `translationGroupId` (UUID)
+- The content API filters by locale — `?locale=es` returns only Spanish pages
+- Single page responses include a `translations` array linking to other language versions
+- Slugs are unique per locale — `/about` can exist in both `en` and `es`
+
+## Setup
+
+### 1. Configure supported locales
+
+Go to **System → Settings** in the admin. Under "Localization":
+
+- **Supported Locales**: Add the language codes you need (e.g., `en`, `es`, `fr`, `de`). Press Enter to add each one.
+- **Default Locale**: Select which locale is used when no `?locale=` param is provided in API requests.
+
+### 2. Create translated pages
+
+On any page in the editor, the sidebar shows a **Translations** card:
+
+- The current page's locale is displayed as a badge
+- Existing translations are listed with links to their editors
+- **"Translate to..."** buttons appear for locales that don't have a translation yet
+
+Clicking "Translate to ES" creates a new draft page with the same slug and content type, linked to the original via the translation group. The new page starts as a draft so you can translate the content before publishing.
+
+### 3. Filter pages by locale
+
+The pages list in the admin has a locale filter dropdown (shown when multiple locales are configured). Use it to view pages in a specific language.
+
+## Content API
+
+### List pages by locale
+
+```
+GET /api/content/pages?type=article&locale=es
+```
+
+If `locale` is omitted, the site's `defaultLocale` is used. Pages are filtered to only return the requested locale.
+
+### Get a single page with translations
+
+```
+GET /api/content/pages/about?locale=es
+```
+
+Response includes the page data plus a `translations` array:
+
+```json
+{
+  "data": {
+    "id": 42,
+    "type": "secondary_page",
+    "title": "Sobre Nosotros",
+    "slug": "about",
+    "locale": "es",
+    "translationGroupId": "550e8400-e29b-41d4-a716-446655440000",
+    "translations": [
+      { "id": 10, "locale": "en", "slug": "about", "title": "About Us" },
+      { "id": 55, "locale": "fr", "slug": "about", "title": "À propos" }
+    ],
+    "regions": { ... },
+    "seo": { ... }
+  }
+}
+```
+
+### Get site locale config
+
+```
+GET /api/content/config
+```
+
+Returns `defaultLocale` and `supportedLocales` alongside other site config.
+
+## Astro integration
+
+### Fetching localized content
+
+```typescript
+// Fetch Spanish articles
+const articles = await client.pages.list({ type: 'article', locale: 'es' });
+
+// Fetch a page in a specific locale
+const page = await client.pages.getBySlug('about', { locale: 'es' });
+
+// Access translations for a language switcher
+const translations = page.translations;
+// [{ id: 10, locale: 'en', slug: 'about', title: 'About Us' }, ...]
+```
+
+### Locale-prefixed routes
+
+A common Astro pattern for multi-language sites:
+
+```
+src/pages/
+  [locale]/
+    [...slug].astro     # /en/about, /es/about, /fr/about
+  [...slug].astro       # /about (redirects to default locale)
+```
+
+In `[locale]/[...slug].astro`:
+
+```astro
+---
+const { locale, slug } = Astro.params;
+const page = await client.pages.getBySlug(slug, { locale });
+if (!page) return Astro.redirect('/404');
+---
+```
+
+### Language switcher component
+
+```astro
+---
+// src/components/LanguageSwitcher.astro
+const { translations, currentLocale } = Astro.props;
+---
+{translations?.length > 0 && (
+  <nav aria-label="Language">
+    {translations.map(t => (
+      <a href={`/${t.locale}/${t.slug}`}
+         aria-current={t.locale === currentLocale ? 'page' : undefined}>
+        {t.locale.toUpperCase()}
+      </a>
+    ))}
+  </nav>
+)}
+```
+
+## Design notes
+
+- **Page-level, not field-level**: Each locale is a separate page with its own blocks, SEO fields, and content. This gives editors full flexibility per language rather than forcing identical page structure across locales.
+- **Slugs are per-locale**: The same slug (`about`) can exist in multiple locales. The content API disambiguates via the `?locale=` parameter.
+- **Translation groups are optional**: A page doesn't need to be translated. Pages without a `translationGroupId` simply exist in one locale.
+- **No content is auto-translated**: WollyCMS creates draft translation pages with the same slug and content type but leaves the actual translation to editors (or external tools).
+
+## Admin API
+
+| Endpoint | Method | Description |
+|---|---|---|
+| `/api/admin/pages` | GET | Filter by `?locale=` |
+| `/api/admin/pages` | POST | Include `locale` in body |
+| `/api/admin/pages/:id/translate` | POST | Create translation: `{ locale: "es" }` |
+| `/api/admin/pages/:id/translations` | GET | List all translations in the group |

--- a/apps/docs/src/content/docs/concepts/i18n.md
+++ b/apps/docs/src/content/docs/concepts/i18n.md
@@ -81,7 +81,16 @@ GET /api/content/config
 
 Returns `defaultLocale` and `supportedLocales` alongside other site config.
 
-## Astro integration
+## Astro frontend setup
+
+WollyCMS handles the content and translation linking, but **your Astro frontend needs to be configured to serve multi-language pages**. This means:
+
+1. **Route structure** — Add locale-prefixed routes so each language has its own URL (e.g., `/en/about`, `/es/about`)
+2. **Locale parameter** — Pass `?locale=` when fetching content from the CMS API
+3. **Language switcher** — Build a component that lets visitors switch between available languages using the `translations` array from the page response
+4. **Site config** — Fetch `supportedLocales` and `defaultLocale` from `/api/content/config` to drive your routing and UI
+
+None of this happens automatically — the CMS stores and serves the data, your frontend decides how to present it. The examples below show the common patterns.
 
 ### Fetching localized content
 

--- a/packages/admin/src/lib/components/PageEditorSidebar.svelte
+++ b/packages/admin/src/lib/components/PageEditorSidebar.svelte
@@ -41,6 +41,9 @@
     onRevisionsReload,
     onPageReload,
     onA11yNavigate,
+    translations,
+    supportedLocales,
+    onTranslate,
   }: {
     pageData: any;
     id: string;
@@ -56,6 +59,9 @@
     onRevisionsReload: () => Promise<void>;
     onPageReload: () => void;
     onA11yNavigate?: (pbId: number, code?: string) => void;
+    translations?: Array<{ id: number; locale: string; title: string; slug: string; status: string }>;
+    supportedLocales?: string[];
+    onTranslate?: (locale: string) => void;
   } = $props();
 
   let showSerpPreview = $state(false);
@@ -224,6 +230,35 @@
     </p>
   </div>
 </div>
+
+<!-- Translations -->
+{#if supportedLocales && supportedLocales.length > 1}
+<div class="card" style="margin-bottom: 1rem;">
+  <h3 style="font-size: 0.95rem; margin-bottom: 0.75rem;">Translations</h3>
+  <p style="font-size: 0.85rem; color: var(--c-text-light); margin-bottom: 0.5rem;">
+    Current: <span class="badge" style="font-size: 0.7rem; background: var(--c-bg-subtle); color: var(--c-text-light);">{pageData.locale?.toUpperCase() || 'EN'}</span>
+  </p>
+  {#if translations && translations.length > 0}
+    <div style="display: flex; flex-direction: column; gap: 0.35rem; margin-bottom: 0.75rem;">
+      {#each translations.filter(t => t.id !== pageData.id) as t}
+        <a href="/admin/pages/{t.id}" style="display: flex; align-items: center; justify-content: space-between; padding: 0.35rem 0.5rem; background: var(--c-bg-subtle); border-radius: var(--radius); font-size: 0.8rem; text-decoration: none; color: var(--c-text);">
+          <span><strong>{t.locale.toUpperCase()}</strong> — {t.title}</span>
+          <span class="badge badge-{t.status}" style="font-size: 0.65rem;">{t.status}</span>
+        </a>
+      {/each}
+    </div>
+  {/if}
+  {#each supportedLocales.filter(loc => loc !== pageData.locale && (!translations || !translations.some(t => t.locale === loc))) as loc}
+    <button
+      class="btn btn-sm btn-outline"
+      style="margin-right: 0.25rem; margin-bottom: 0.25rem;"
+      onclick={() => onTranslate?.(loc)}
+    >
+      Translate to {loc.toUpperCase()}
+    </button>
+  {/each}
+</div>
+{/if}
 
 <div class="card" style="margin-bottom: 1rem;">
   <h3 style="font-size: 0.95rem; margin-bottom: 0.75rem;">SEO & Meta</h3>

--- a/packages/admin/src/routes/pages/+page.svelte
+++ b/packages/admin/src/routes/pages/+page.svelte
@@ -23,10 +23,13 @@
   let search = $state('');
   let statusFilter = $state('');
   let typeFilter = $state('');
+  let localeFilter = $state('');
+  let supportedLocales = $state<string[]>(['en']);
+  let defaultLocale = $state('en');
   let sortBy = $state('updated_at:desc');
   let showCreate = $state(false);
   let contentTypes = $state<any[]>([]);
-  let newPage = $state({ title: '', slug: '', typeId: 0, status: 'draft' as string });
+  let newPage = $state({ title: '', slug: '', typeId: 0, status: 'draft' as string, locale: '' });
   let slugManuallyEdited = $state(false);
   let selected = $state<Set<number>>(new Set());
   let pageSize = 20;
@@ -46,6 +49,7 @@
       if (search) params.set('search', search);
       if (statusFilter) params.set('status', statusFilter);
       if (typeFilter) params.set('type', typeFilter);
+      if (localeFilter) params.set('locale', localeFilter);
       if (sortBy) params.set('sort', sortBy);
       params.set('limit', String(pageSize));
       params.set('offset', String(offset));
@@ -66,7 +70,15 @@
     if (contentTypes.length > 0) newPage.typeId = contentTypes[0].id;
   }
 
-  onMount(() => { load(); loadTypes(); });
+  async function loadLocaleConfig() {
+    try {
+      const res = await api.get<{ data: any }>('/config');
+      supportedLocales = res.data.supportedLocales || ['en'];
+      defaultLocale = res.data.defaultLocale || 'en';
+    } catch { /* use defaults */ }
+  }
+
+  onMount(() => { load(); loadTypes(); loadLocaleConfig(); });
 
   let createError = $state('');
 
@@ -91,9 +103,10 @@
         status: newPage.status,
       };
       if (newPage.slug.trim()) payload.slug = newPage.slug.trim();
+      if (newPage.locale) payload.locale = newPage.locale;
       const res = await api.post<{ data: { id: number } }>('/pages', payload);
       showCreate = false;
-      newPage = { title: '', slug: '', typeId: contentTypes[0]?.id || 0, status: 'draft' };
+      newPage = { title: '', slug: '', typeId: contentTypes[0]?.id || 0, status: 'draft', locale: '' };
       slugManuallyEdited = false;
       goto(`${base}/pages/${res.data.id}`);
     } catch (err: any) {
@@ -188,6 +201,14 @@
     <option value="draft">Draft</option>
     <option value="archived">Archived</option>
   </select>
+  {#if supportedLocales.length > 1}
+    <select class="form-control" bind:value={localeFilter} onchange={() => { offset = 0; load(); }} style="max-width: 120px;">
+      <option value="">All locales</option>
+      {#each supportedLocales as loc}
+        <option value={loc}>{loc.toUpperCase()}</option>
+      {/each}
+    </select>
+  {/if}
   <select class="form-control" bind:value={sortBy} onchange={() => { offset = 0; load(); }} style="max-width: 180px;">
     <option value="updated_at:desc">Last updated</option>
     <option value="updated_at:asc">Oldest updated</option>
@@ -210,7 +231,7 @@
     <thead>
       <tr>
         <th style="width: 32px;"><input type="checkbox" checked={allSelected} onchange={toggleAll} aria-label="Select all pages" /></th>
-        <th>Title</th><th>Slug</th><th>Type</th><th>Status</th>
+        <th>Title</th><th>Slug</th><th>Locale</th><th>Type</th><th>Status</th>
         <th aria-sort={updatedSortDirection}>
           <button
             type="button"
@@ -231,6 +252,7 @@
             <td><div class="skeleton" style="width: 16px; height: 16px; border-radius: 3px;"></div></td>
             <td><div class="skeleton skeleton-text" style="width: 70%;"></div></td>
             <td><div class="skeleton skeleton-text" style="width: 50%;"></div></td>
+            <td><div class="skeleton" style="width: 28px; height: 18px; border-radius: 4px;"></div></td>
             <td><div class="skeleton skeleton-text" style="width: 80%;"></div></td>
             <td><div class="skeleton" style="width: 72px; height: 22px; border-radius: 999px;"></div></td>
             <td><div class="skeleton skeleton-text" style="width: 60%;"></div></td>
@@ -239,7 +261,7 @@
         {/each}
       {:else if pages.length === 0}
         <tr>
-          <td colspan="7">
+          <td colspan="8">
             <div class="empty-state">
               <div class="empty-state-title">No pages found</div>
               <p>{search || statusFilter || typeFilter ? 'Try adjusting your filters.' : 'Create your first page to get started.'}</p>
@@ -252,6 +274,7 @@
             <td><input type="checkbox" checked={selected.has(page.id)} onchange={() => toggleSelect(page.id)} aria-label={"Select page " + page.title} /></td>
             <td class="td-title"><span class="type-bar"></span><a href="{base}/pages/{page.id}"><strong>{page.title}</strong></a></td>
             <td class="mono" style="color: var(--c-text-light);">/{page.slug}</td>
+            <td><span class="badge" style="font-size: 0.7rem; background: var(--c-bg-subtle); color: var(--c-text-light);">{page.locale?.toUpperCase() || 'EN'}</span></td>
             <td>{page.typeName}</td>
             <td><span class="badge badge-{page.status}">{page.status}</span></td>
             <td>{new Date(page.meta.updated_at).toLocaleDateString()}</td>
@@ -311,6 +334,17 @@
             {/each}
           </select>
         </div>
+        {#if supportedLocales.length > 1}
+          <div class="form-group">
+            <label for="np-locale">Locale</label>
+            <select id="np-locale" class="form-control" bind:value={newPage.locale}>
+              <option value="">Default ({defaultLocale})</option>
+              {#each supportedLocales as loc}
+                <option value={loc}>{loc.toUpperCase()}</option>
+              {/each}
+            </select>
+          </div>
+        {/if}
         <div class="form-group">
           <label for="np-status">Status</label>
           <select id="np-status" class="form-control" bind:value={newPage.status}>

--- a/packages/admin/src/routes/pages/[id]/+page.svelte
+++ b/packages/admin/src/routes/pages/[id]/+page.svelte
@@ -31,6 +31,8 @@
   let allMenus = $state<any[]>([]);
   let menuDetails = $state<Record<number, any>>({});
   let revisions = $state<any[]>([]);
+  let translations = $state<any[]>([]);
+  let supportedLocales = $state<string[]>(['en']);
   let previewPanel = $state<PreviewPanel | null>(null);
   let blockEditor = $state<BlockEditorRegion | null>(null);
 
@@ -158,6 +160,8 @@
       }
       await loadMenuDetails();
       await loadMediaCache();
+      loadTranslations();
+      loadLocaleConfig();
       takeSnapshot();
       dirty = false; blocksDirtyTick = 0;
     } catch (err: any) { error = err.message; }
@@ -178,6 +182,20 @@
       const res = await api.get<{ data: any[] }>(`/pages/${id}/revisions`);
       revisions = res.data;
     } catch { revisions = []; }
+  }
+
+  async function loadTranslations() {
+    try {
+      const res = await api.get<{ data: any[] }>(`/pages/${id}/translations`);
+      translations = res.data;
+    } catch { /* ignore */ }
+  }
+
+  async function loadLocaleConfig() {
+    try {
+      const res = await api.get<{ data: any }>('/config');
+      supportedLocales = res.data.supportedLocales || ['en'];
+    } catch { /* ignore */ }
   }
 
   /** Load media metadata for alt-text checks */
@@ -203,6 +221,15 @@
 
   function handleA11yNavigate(pbId: number, a11yCode?: string) {
     blockEditor?.scrollToBlock(`pb_${pbId}`, a11yCode);
+  }
+
+  async function handleTranslate(targetLocale: string) {
+    try {
+      const res = await api.post<{ data: { id: number } }>(`/pages/${id}/translate`, { locale: targetLocale });
+      goto(`${base}/pages/${res.data.id}`);
+    } catch (err: any) {
+      toast.error(err.message || 'Failed to create translation');
+    }
   }
 
   onMount(load);
@@ -300,6 +327,9 @@
           <statusConfig.icon size={12} />
           {statusConfig.label}
         </span>
+        {#if pageData.locale}
+          <span class="badge" style="font-size: 0.75rem; background: var(--c-bg-subtle); color: var(--c-text-light);">{pageData.locale.toUpperCase()}</span>
+        {/if}
       </div>
       <div class="slug-row">
         {#if editingSlug}
@@ -390,6 +420,8 @@
         <PageEditorSidebar
           {pageData} {id} {allMenus} {menuDetails} {revisions}
           {a11yIssues} {seoChecks} {siteUrl}
+          {translations} {supportedLocales}
+          onTranslate={handleTranslate}
           bind:success bind:error
           onMenuDetailsReload={loadMenuDetails}
           onRevisionsReload={loadRevisions}

--- a/packages/admin/src/routes/settings/+page.svelte
+++ b/packages/admin/src/routes/settings/+page.svelte
@@ -63,6 +63,60 @@
     </div>
 
     <hr style="margin: 1.5rem 0; border: none; border-top: 1px solid var(--c-border);" />
+    <h2 style="font-size: 1.1rem; margin-bottom: 1rem;">Localization</h2>
+    <div class="form-group">
+      <label>Default Locale</label>
+      <select class="form-control" bind:value={config.defaultLocale} style="max-width: 200px;">
+        {#each (config.supportedLocales || ['en']) as loc}
+          <option value={loc}>{loc}</option>
+        {/each}
+      </select>
+      <p style="font-size: 0.8rem; color: var(--c-text-light); margin-top: 0.25rem;">
+        Used when no locale is specified in API requests.
+      </p>
+    </div>
+    <div class="form-group">
+      <label>Supported Locales</label>
+      <div style="display: flex; flex-wrap: wrap; gap: 0.35rem; margin-bottom: 0.5rem;">
+        {#each (config.supportedLocales || ['en']) as loc, i}
+          <span style="display: inline-flex; align-items: center; gap: 0.25rem; padding: 0.25rem 0.5rem; background: var(--c-bg-subtle); border-radius: var(--radius); font-size: 0.85rem;">
+            {loc}
+            {#if config.supportedLocales.length > 1}
+              <button
+                type="button"
+                style="background: none; border: none; cursor: pointer; color: var(--c-text-light); font-size: 0.75rem; padding: 0;"
+                onclick={() => {
+                  config.supportedLocales = config.supportedLocales.filter((_: string, j: number) => j !== i);
+                  if (config.defaultLocale === loc) config.defaultLocale = config.supportedLocales[0];
+                }}
+                aria-label="Remove {loc}"
+              >&times;</button>
+            {/if}
+          </span>
+        {/each}
+      </div>
+      <div style="display: flex; gap: 0.35rem; align-items: center;">
+        <input
+          class="form-control"
+          placeholder="e.g. es, fr, de"
+          style="max-width: 120px; font-size: 0.85rem;"
+          onkeydown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault();
+              const input = e.target as HTMLInputElement;
+              const val = input.value.trim().toLowerCase();
+              if (val && val.length >= 2 && !config.supportedLocales.includes(val)) {
+                config.supportedLocales = [...config.supportedLocales, val];
+                input.value = '';
+              }
+            }
+          }}
+        />
+        <span style="font-size: 0.75rem; color: var(--c-text-light);">Press Enter to add</span>
+      </div>
+    </div>
+
+    <hr style="margin: 1.5rem 0; border: none; border-top: 1px solid var(--c-border);" />
     <h2 style="font-size: 1.1rem; margin-bottom: 1rem;">Social Links</h2>
     <div class="form-group">
       <label>Facebook</label>

--- a/packages/astro/src/types.ts
+++ b/packages/astro/src/types.ts
@@ -34,9 +34,17 @@ export interface PageSummary {
   title: string;
   slug: string;
   status: 'draft' | 'published' | 'archived';
+  locale?: string;
   fields: Record<string, unknown>;
   terms?: PageTerm[];
   meta: PageMeta;
+}
+
+export interface PageTranslation {
+  id: number;
+  locale: string;
+  slug: string;
+  title: string;
 }
 
 /** Resolved block in a page region */
@@ -62,6 +70,8 @@ export interface PageSeo {
 export interface Page extends PageSummary {
   regions: Record<string, ResolvedBlock[]>;
   seo?: PageSeo;
+  translationGroupId?: string | null;
+  translations?: PageTranslation[];
 }
 
 /** Menu item (recursive tree) */
@@ -211,4 +221,16 @@ export interface PageListParams {
   limit?: number;
   offset?: number;
   status?: string;
+  locale?: string;
+}
+
+/** Site configuration (from content API /config) */
+export interface SiteConfig {
+  siteName: string;
+  tagline: string;
+  logo: string | null;
+  footer: { text: string };
+  social: { facebook: string | null; twitter: string | null; instagram: string | null };
+  defaultLocale: string;
+  supportedLocales: string[];
 }

--- a/packages/server/drizzle/0018_i18n.sql
+++ b/packages/server/drizzle/0018_i18n.sql
@@ -1,0 +1,15 @@
+-- Add locale and translation support to pages
+ALTER TABLE `pages` ADD `locale` text NOT NULL DEFAULT 'en';
+--> statement-breakpoint
+ALTER TABLE `pages` ADD `translation_group_id` text;
+--> statement-breakpoint
+ALTER TABLE `page_revisions` ADD `locale` text NOT NULL DEFAULT 'en';
+--> statement-breakpoint
+-- Replace global slug uniqueness with per-locale uniqueness
+DROP INDEX IF EXISTS `pages_slug_unique`;
+--> statement-breakpoint
+CREATE UNIQUE INDEX `pages_slug_locale_unique` ON `pages` (`slug`, `locale`);
+--> statement-breakpoint
+CREATE INDEX `idx_pages_locale` ON `pages` (`locale`);
+--> statement-breakpoint
+CREATE INDEX `idx_pages_translation_group` ON `pages` (`translation_group_id`);

--- a/packages/server/drizzle/meta/0018_snapshot.json
+++ b/packages/server/drizzle/meta/0018_snapshot.json
@@ -1,0 +1,2011 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "d008e329-52e6-492b-82af-f3e43c5813d9",
+  "prevId": "5ae5e5cb-174f-4a91-bdfe-03d7372ac3dc",
+  "tables": {
+    "api_keys": {
+      "name": "api_keys",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "permissions": {
+          "name": "permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'content:read'"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "columns": [
+            "key_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_logs": {
+      "name": "audit_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_name": {
+          "name": "user_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity": {
+          "name": "entity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "details": {
+          "name": "details",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "block_types": {
+      "name": "block_types",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fields_schema": {
+          "name": "fields_schema",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "block_types_slug_unique": {
+          "name": "block_types_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blocks": {
+      "name": "blocks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fields": {
+          "name": "fields",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_reusable": {
+          "name": "is_reusable",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_blocks_type": {
+          "name": "idx_blocks_type",
+          "columns": [
+            "type_id"
+          ],
+          "isUnique": false
+        },
+        "idx_blocks_reusable": {
+          "name": "idx_blocks_reusable",
+          "columns": [
+            "is_reusable"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "blocks_type_id_block_types_id_fk": {
+          "name": "blocks_type_id_block_types_id_fk",
+          "tableFrom": "blocks",
+          "tableTo": "block_types",
+          "columnsFrom": [
+            "type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "blocks_created_by_users_id_fk": {
+          "name": "blocks_created_by_users_id_fk",
+          "tableFrom": "blocks",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "content_terms": {
+      "name": "content_terms",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "term_id": {
+          "name": "term_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_content_terms_entity": {
+          "name": "idx_content_terms_entity",
+          "columns": [
+            "entity_type",
+            "entity_id"
+          ],
+          "isUnique": false
+        },
+        "idx_content_terms_term": {
+          "name": "idx_content_terms_term",
+          "columns": [
+            "term_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "content_terms_term_id_terms_id_fk": {
+          "name": "content_terms_term_id_terms_id_fk",
+          "tableFrom": "content_terms",
+          "tableTo": "terms",
+          "columnsFrom": [
+            "term_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "content_types": {
+      "name": "content_types",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fields_schema": {
+          "name": "fields_schema",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "regions": {
+          "name": "regions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "default_blocks": {
+          "name": "default_blocks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "content_types_slug_unique": {
+          "name": "content_types_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media": {
+      "name": "media",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "alt_text": {
+          "name": "alt_text",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "folder": {
+          "name": "folder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variants": {
+          "name": "variants",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_media_mime": {
+          "name": "idx_media_mime",
+          "columns": [
+            "mime_type"
+          ],
+          "isUnique": false
+        },
+        "idx_media_folder": {
+          "name": "idx_media_folder",
+          "columns": [
+            "folder"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "media_created_by_users_id_fk": {
+          "name": "media_created_by_users_id_fk",
+          "tableFrom": "media",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "menu_items": {
+      "name": "menu_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "menu_id": {
+          "name": "menu_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "target": {
+          "name": "target",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'_self'"
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "depth": {
+          "name": "depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_expanded": {
+          "name": "is_expanded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "attributes": {
+          "name": "attributes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_menu_items_menu": {
+          "name": "idx_menu_items_menu",
+          "columns": [
+            "menu_id"
+          ],
+          "isUnique": false
+        },
+        "idx_menu_items_parent": {
+          "name": "idx_menu_items_parent",
+          "columns": [
+            "parent_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "menu_items_menu_id_menus_id_fk": {
+          "name": "menu_items_menu_id_menus_id_fk",
+          "tableFrom": "menu_items",
+          "tableTo": "menus",
+          "columnsFrom": [
+            "menu_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "menu_items_page_id_pages_id_fk": {
+          "name": "menu_items_page_id_pages_id_fk",
+          "tableFrom": "menu_items",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "menus": {
+      "name": "menus",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "menus_slug_unique": {
+          "name": "menus_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "page_blocks": {
+      "name": "page_blocks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "block_id": {
+          "name": "block_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "region": {
+          "name": "region",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_shared": {
+          "name": "is_shared",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "overrides": {
+          "name": "overrides",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_page_blocks_page": {
+          "name": "idx_page_blocks_page",
+          "columns": [
+            "page_id"
+          ],
+          "isUnique": false
+        },
+        "idx_page_blocks_block": {
+          "name": "idx_page_blocks_block",
+          "columns": [
+            "block_id"
+          ],
+          "isUnique": false
+        },
+        "idx_page_blocks_page_region": {
+          "name": "idx_page_blocks_page_region",
+          "columns": [
+            "page_id",
+            "region"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "page_blocks_page_id_pages_id_fk": {
+          "name": "page_blocks_page_id_pages_id_fk",
+          "tableFrom": "page_blocks",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "page_blocks_block_id_blocks_id_fk": {
+          "name": "page_blocks_block_id_blocks_id_fk",
+          "tableFrom": "page_blocks",
+          "tableTo": "blocks",
+          "columnsFrom": [
+            "block_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "page_revisions": {
+      "name": "page_revisions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "page_id": {
+          "name": "page_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'en'"
+        },
+        "fields": {
+          "name": "fields",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "blocks": {
+          "name": "blocks",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_revisions_page": {
+          "name": "idx_revisions_page",
+          "columns": [
+            "page_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "page_revisions_page_id_pages_id_fk": {
+          "name": "page_revisions_page_id_pages_id_fk",
+          "tableFrom": "page_revisions",
+          "tableTo": "pages",
+          "columnsFrom": [
+            "page_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "page_revisions_created_by_users_id_fk": {
+          "name": "page_revisions_created_by_users_id_fk",
+          "tableFrom": "page_revisions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pages": {
+      "name": "pages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "type_id": {
+          "name": "type_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'draft'"
+        },
+        "locale": {
+          "name": "locale",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'en'"
+        },
+        "translation_group_id": {
+          "name": "translation_group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fields": {
+          "name": "fields",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scheduled_at": {
+          "name": "scheduled_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "unpublish_at": {
+          "name": "unpublish_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "meta_title": {
+          "name": "meta_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "meta_description": {
+          "name": "meta_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "og_image": {
+          "name": "og_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "canonical_url": {
+          "name": "canonical_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "robots": {
+          "name": "robots",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pages_slug_locale_unique": {
+          "name": "pages_slug_locale_unique",
+          "columns": [
+            "slug",
+            "locale"
+          ],
+          "isUnique": true
+        },
+        "idx_pages_slug": {
+          "name": "idx_pages_slug",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": false
+        },
+        "idx_pages_type": {
+          "name": "idx_pages_type",
+          "columns": [
+            "type_id"
+          ],
+          "isUnique": false
+        },
+        "idx_pages_status": {
+          "name": "idx_pages_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_pages_type_status": {
+          "name": "idx_pages_type_status",
+          "columns": [
+            "type_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_pages_locale": {
+          "name": "idx_pages_locale",
+          "columns": [
+            "locale"
+          ],
+          "isUnique": false
+        },
+        "idx_pages_translation_group": {
+          "name": "idx_pages_translation_group",
+          "columns": [
+            "translation_group_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pages_type_id_content_types_id_fk": {
+          "name": "pages_type_id_content_types_id_fk",
+          "tableFrom": "pages",
+          "tableTo": "content_types",
+          "columnsFrom": [
+            "type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pages_created_by_users_id_fk": {
+          "name": "pages_created_by_users_id_fk",
+          "tableFrom": "pages",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "redirects": {
+      "name": "redirects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "from_path": {
+          "name": "from_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "to_path": {
+          "name": "to_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status_code": {
+          "name": "status_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 301
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "idx_redirects_from": {
+          "name": "idx_redirects_from",
+          "columns": [
+            "from_path"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "site_config": {
+      "name": "site_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'{}'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "single_row": {
+          "name": "single_row",
+          "value": "\"site_config\".\"id\" = 1"
+        }
+      }
+    },
+    "taxonomies": {
+      "name": "taxonomies",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "hierarchical": {
+          "name": "hierarchical",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "taxonomies_slug_unique": {
+          "name": "taxonomies_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "terms": {
+      "name": "terms",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "taxonomy_id": {
+          "name": "taxonomy_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "weight": {
+          "name": "weight",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "fields": {
+          "name": "fields",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_terms_taxonomy": {
+          "name": "idx_terms_taxonomy",
+          "columns": [
+            "taxonomy_id"
+          ],
+          "isUnique": false
+        },
+        "idx_terms_parent": {
+          "name": "idx_terms_parent",
+          "columns": [
+            "parent_id"
+          ],
+          "isUnique": false
+        },
+        "idx_terms_slug": {
+          "name": "idx_terms_slug",
+          "columns": [
+            "taxonomy_id",
+            "slug"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "terms_taxonomy_id_taxonomies_id_fk": {
+          "name": "terms_taxonomy_id_taxonomies_id_fk",
+          "tableFrom": "terms",
+          "tableTo": "taxonomies",
+          "columnsFrom": [
+            "taxonomy_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tracking_scripts": {
+      "name": "tracking_scripts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'head'"
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'global'"
+        },
+        "target_pages": {
+          "name": "target_pages",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "trusted_devices": {
+      "name": "trusted_devices",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "trusted_devices_token_hash_unique": {
+          "name": "trusted_devices_token_hash_unique",
+          "columns": [
+            "token_hash"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "trusted_devices_user_id_users_id_fk": {
+          "name": "trusted_devices_user_id_users_id_fk",
+          "tableFrom": "trusted_devices",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_oauth": {
+      "name": "user_oauth",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_oauth_provider_unique": {
+          "name": "user_oauth_provider_unique",
+          "columns": [
+            "provider",
+            "provider_id"
+          ],
+          "isUnique": true
+        },
+        "user_oauth_user_provider_unique": {
+          "name": "user_oauth_user_provider_unique",
+          "columns": [
+            "user_id",
+            "provider"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_oauth_user_id_users_id_fk": {
+          "name": "user_oauth_user_id_users_id_fk",
+          "tableFrom": "user_oauth",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_recovery_codes": {
+      "name": "user_recovery_codes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "code_hash": {
+          "name": "code_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_recovery_codes_user_id_users_id_fk": {
+          "name": "user_recovery_codes_user_id_users_id_fk",
+          "tableFrom": "user_recovery_codes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_totp": {
+      "name": "user_totp",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_totp_user_id_unique": {
+          "name": "user_totp_user_id_unique",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "user_totp_user_id_users_id_fk": {
+          "name": "user_totp_user_id_users_id_fk",
+          "tableFrom": "user_totp",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'editor'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webhooks": {
+      "name": "webhooks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "events": {
+          "name": "events",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_triggered_at": {
+          "name": "last_triggered_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_status": {
+          "name": "last_status",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1774190230323,
       "tag": "0017_brown_doctor_strange",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "6",
+      "when": 1774200000000,
+      "tag": "0018_i18n",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/api/admin/config.ts
+++ b/packages/server/src/api/admin/config.ts
@@ -22,9 +22,11 @@ const defaultConfig = {
     twitter: null as string | null,
     instagram: null as string | null,
   },
+  defaultLocale: 'en',
+  supportedLocales: ['en'] as string[],
 };
 
-async function loadConfig(): Promise<typeof defaultConfig> {
+export async function loadConfig(): Promise<typeof defaultConfig> {
   const db = getDb();
   const row = await db.select().from(siteConfig).where(eq(siteConfig.id, 1)).get?.()
     ?? (await db.select().from(siteConfig).where(eq(siteConfig.id, 1)))[0];
@@ -75,6 +77,8 @@ app.put('/', async (c) => {
       twitter: z.string().nullable().optional(),
       instagram: z.string().nullable().optional(),
     }).optional(),
+    defaultLocale: z.string().min(2).max(10).optional(),
+    supportedLocales: z.array(z.string().min(2).max(10)).min(1).optional(),
   }).safeParse(body);
   if (!parsed.success) return c.json({ errors: parsed.error.issues.map((i) => ({ code: 'VALIDATION', message: i.message })) }, 400);
 

--- a/packages/server/src/api/admin/pages.ts
+++ b/packages/server/src/api/admin/pages.ts
@@ -12,6 +12,7 @@ import { clearOgCache } from '../content/og-image.js';
 import pageBlocksRouter from './page-blocks.js';
 import pageTermsRouter from './page-terms.js';
 import { requireRole } from '../../auth/rbac.js';
+import { loadConfig } from './config.js';
 
 const app = new Hono();
 
@@ -32,6 +33,8 @@ const pageSchema = z.object({
   ogImage: z.string().nullable().optional(),
   canonicalUrl: z.string().nullable().optional(),
   robots: z.string().nullable().optional(),
+  locale: z.string().min(2).max(10).optional(),
+  translationGroupId: z.string().nullable().optional(),
 });
 
 const pageUpdateSchema = pageSchema.partial().extend({
@@ -48,6 +51,7 @@ app.get('/', async (c) => {
   const typeSlug = c.req.query('type');
   const status = c.req.query('status');
   const search = c.req.query('search');
+  const locale = c.req.query('locale');
   const sortParam = c.req.query('sort') || 'updated_at:desc';
   const limit = Math.min(parseInt(c.req.query('limit') || '50', 10), 100);
   const offset = parseInt(c.req.query('offset') || '0', 10);
@@ -66,6 +70,8 @@ app.get('/', async (c) => {
       publishedAt: pages.publishedAt,
       scheduledAt: pages.scheduledAt,
       unpublishAt: pages.unpublishAt,
+      locale: pages.locale,
+      translationGroupId: pages.translationGroupId,
     })
     .from(pages)
     .innerJoin(contentTypes, eq(pages.typeId, contentTypes.id))
@@ -73,6 +79,7 @@ app.get('/', async (c) => {
 
   const conditions: ReturnType<typeof eq>[] = [];
   if (status) conditions.push(eq(pages.status, status as 'draft' | 'published' | 'archived'));
+  if (locale) conditions.push(eq(pages.locale, locale));
 
   if (typeSlug) {
     const [typeRow] = await db.select({ id: contentTypes.id }).from(contentTypes).where(eq(contentTypes.slug, typeSlug)).limit(1);
@@ -102,6 +109,8 @@ app.get('/', async (c) => {
       status: r.status, fields: r.fields,
       scheduledAt: r.scheduledAt,
       unpublishAt: r.unpublishAt,
+      locale: r.locale,
+      translationGroupId: r.translationGroupId,
       meta: { created_at: r.createdAt, updated_at: r.updatedAt, published_at: r.publishedAt },
     })),
     meta: { total: countResult[0].count, limit, offset },
@@ -149,6 +158,7 @@ app.get('/:id', async (c) => {
       scheduledAt: pages.scheduledAt,
       metaTitle: pages.metaTitle, metaDescription: pages.metaDescription,
       ogImage: pages.ogImage, canonicalUrl: pages.canonicalUrl, robots: pages.robots,
+      locale: pages.locale, translationGroupId: pages.translationGroupId,
       createdAt: pages.createdAt, updatedAt: pages.updatedAt, publishedAt: pages.publishedAt,
     })
     .from(pages)
@@ -192,6 +202,7 @@ app.get('/:id', async (c) => {
       unpublishAt: page.unpublishAt,
       metaTitle: page.metaTitle, metaDescription: page.metaDescription,
       ogImage: page.ogImage, canonicalUrl: page.canonicalUrl, robots: page.robots,
+      locale: page.locale, translationGroupId: page.translationGroupId,
       regions,
       meta: { created_at: page.createdAt, updated_at: page.updatedAt, published_at: page.publishedAt },
     },
@@ -205,11 +216,13 @@ app.post('/', async (c) => {
   if (!parsed.success) return c.json({ errors: parsed.error.issues.map((i) => ({ code: 'VALIDATION', message: i.message, path: i.path })) }, 400);
 
   const db = getDb();
+  const config = await loadConfig();
   const payload = c.get('jwtPayload');
   const now = new Date().toISOString();
   const slug = parsed.data.slug || slugify(parsed.data.title);
+  const pageLocale = parsed.data.locale || config.defaultLocale;
 
-  const existing = await db.select({ id: pages.id }).from(pages).where(eq(pages.slug, slug)).limit(1);
+  const existing = await db.select({ id: pages.id }).from(pages).where(and(eq(pages.slug, slug), eq(pages.locale, pageLocale))).limit(1);
   if (existing.length > 0) return c.json({ errors: [{ code: 'CONFLICT', message: 'Slug already exists' }] }, 409);
 
   const [row] = await db.insert(pages).values({
@@ -217,6 +230,8 @@ app.post('/', async (c) => {
     title: parsed.data.title,
     slug,
     status: parsed.data.status,
+    locale: pageLocale,
+    translationGroupId: parsed.data.translationGroupId || null,
     fields: parsed.data.fields,
     scheduledAt: parsed.data.scheduledAt ?? null,
     unpublishAt: parsed.data.unpublishAt ?? null,
@@ -277,11 +292,13 @@ app.post('/upsert', async (c) => {
   if (!parsed.success) return c.json({ errors: parsed.error.issues.map((i) => ({ code: 'VALIDATION', message: i.message, path: i.path })) }, 400);
 
   const db = getDb();
+  const config = await loadConfig();
   const payload = c.get('jwtPayload');
   const now = new Date().toISOString();
   const slug = parsed.data.slug || slugify(parsed.data.title);
+  const pageLocale = parsed.data.locale || config.defaultLocale;
 
-  const [existing] = await db.select().from(pages).where(eq(pages.slug, slug)).limit(1);
+  const [existing] = await db.select().from(pages).where(and(eq(pages.slug, slug), eq(pages.locale, pageLocale))).limit(1);
 
   if (!existing) {
     // Create — same logic as POST /
@@ -290,6 +307,8 @@ app.post('/upsert', async (c) => {
       title: parsed.data.title,
       slug,
       status: parsed.data.status,
+      locale: pageLocale,
+      translationGroupId: parsed.data.translationGroupId || null,
       fields: parsed.data.fields,
       scheduledAt: parsed.data.scheduledAt ?? null,
       createdAt: now,
@@ -436,7 +455,8 @@ app.put('/:id', async (c) => {
   if (!existing) return c.json({ errors: [{ code: 'NOT_FOUND', message: 'Page not found' }] }, 404);
 
   if (parsed.data.slug && parsed.data.slug !== existing.slug) {
-    const dup = await db.select({ id: pages.id }).from(pages).where(eq(pages.slug, parsed.data.slug)).limit(1);
+    const checkLocale = parsed.data.locale || existing.locale;
+    const dup = await db.select({ id: pages.id }).from(pages).where(and(eq(pages.slug, parsed.data.slug), eq(pages.locale, checkLocale))).limit(1);
     if (dup.length > 0) return c.json({ errors: [{ code: 'CONFLICT', message: 'Slug already exists' }] }, 409);
   }
 
@@ -475,6 +495,9 @@ app.put('/:id', async (c) => {
 
   const { revisionNote: _note, ...pageFields } = parsed.data;
   const updates: Record<string, unknown> = { ...pageFields, updatedAt: now };
+  if (parsed.data.translationGroupId !== undefined) {
+    updates.translationGroupId = parsed.data.translationGroupId;
+  }
   if (parsed.data.status === 'published' && !existing.publishedAt) {
     updates.publishedAt = now;
   }
@@ -523,6 +546,81 @@ app.delete('/:id', async (c) => {
   cacheInvalidate('pages:');
   clearOgCache();
   return c.json({ data: { deleted: true } });
+});
+
+/** POST /:id/translate - Create a translation of an existing page. */
+app.post('/:id/translate', async (c) => {
+  const id = parseInt(c.req.param('id'), 10);
+  const body = await c.req.json().catch(() => null);
+  const parsed = z.object({ locale: z.string().min(2).max(10) }).safeParse(body);
+  if (!parsed.success) {
+    return c.json({ errors: [{ code: 'VALIDATION', message: 'Target locale required' }] }, 400);
+  }
+
+  const db = getDb();
+  const [source] = await db.select().from(pages).where(eq(pages.id, id)).limit(1);
+  if (!source) return c.json({ errors: [{ code: 'NOT_FOUND', message: 'Page not found' }] }, 404);
+
+  // Check target locale doesn't already exist for this slug
+  const [existing] = await db.select({ id: pages.id }).from(pages)
+    .where(and(eq(pages.slug, source.slug), eq(pages.locale, parsed.data.locale)))
+    .limit(1);
+  if (existing) {
+    return c.json({ errors: [{ code: 'CONFLICT', message: 'Translation already exists for this locale' }] }, 409);
+  }
+
+  // Ensure source has a translationGroupId
+  let groupId = source.translationGroupId;
+  if (!groupId) {
+    groupId = crypto.randomUUID();
+    await db.update(pages).set({ translationGroupId: groupId }).where(eq(pages.id, id));
+  }
+
+  // Check if a translation already exists in this group for the target locale
+  const [groupExisting] = await db.select({ id: pages.id }).from(pages)
+    .where(and(eq(pages.translationGroupId, groupId), eq(pages.locale, parsed.data.locale)))
+    .limit(1);
+  if (groupExisting) {
+    return c.json({ errors: [{ code: 'CONFLICT', message: 'Translation already exists in this group' }] }, 409);
+  }
+
+  const now = new Date().toISOString();
+  const payload = c.get('jwtPayload');
+  const [newPage] = await db.insert(pages).values({
+    typeId: source.typeId,
+    title: source.title,
+    slug: source.slug,
+    status: 'draft',
+    locale: parsed.data.locale,
+    translationGroupId: groupId,
+    fields: source.fields,
+    metaTitle: source.metaTitle,
+    metaDescription: source.metaDescription,
+    ogImage: source.ogImage,
+    canonicalUrl: source.canonicalUrl,
+    robots: source.robots,
+    createdAt: now,
+    updatedAt: now,
+    createdBy: payload.sub,
+  }).returning();
+
+  return c.json({ data: { id: newPage.id, locale: parsed.data.locale, translationGroupId: groupId } }, 201);
+});
+
+/** GET /:id/translations - Get all translations of a page. */
+app.get('/:id/translations', async (c) => {
+  const id = parseInt(c.req.param('id'), 10);
+  const db = getDb();
+  const [page] = await db.select({ translationGroupId: pages.translationGroupId }).from(pages)
+    .where(eq(pages.id, id)).limit(1);
+  if (!page) return c.json({ errors: [{ code: 'NOT_FOUND', message: 'Page not found' }] }, 404);
+  if (!page.translationGroupId) return c.json({ data: [] });
+
+  const siblings = await db.select({
+    id: pages.id, locale: pages.locale, title: pages.title, slug: pages.slug, status: pages.status,
+  }).from(pages).where(eq(pages.translationGroupId, page.translationGroupId));
+
+  return c.json({ data: siblings });
 });
 
 // Mount page-block sub-routes (add/update/delete blocks, duplicate, reorder)

--- a/packages/server/src/api/content/config.ts
+++ b/packages/server/src/api/content/config.ts
@@ -1,25 +1,20 @@
 import { Hono } from 'hono';
+import { loadConfig } from '../admin/config.js';
 
 const app = new Hono();
 
-/**
- * GET / - Return site configuration.
- * Hardcoded for now; will be backed by a settings table later.
- */
-app.get('/', (c) => {
+/** GET / - Return public site configuration (includes locale settings). */
+app.get('/', async (c) => {
+  const config = await loadConfig();
   return c.json({
     data: {
-      siteName: 'My Site',
-      tagline: 'Welcome to your site',
-      logo: null,
-      footer: {
-        text: 'Built with WollyCMS',
-      },
-      social: {
-        facebook: null,
-        twitter: null,
-        instagram: null,
-      },
+      siteName: config.siteName,
+      tagline: config.tagline,
+      logo: config.logo,
+      footer: config.footer,
+      social: config.social,
+      defaultLocale: config.defaultLocale,
+      supportedLocales: config.supportedLocales,
     },
   });
 });

--- a/packages/server/src/api/content/pages.ts
+++ b/packages/server/src/api/content/pages.ts
@@ -12,11 +12,13 @@ import {
   taxonomies,
 } from '../../db/schema/index.js';
 import { cacheGet, cacheSet } from '../../cache.js';
+import { loadConfig } from '../admin/config.js';
 
 const app = new Hono();
 
 /**
  * GET / - List published pages with filtering, sorting, pagination.
+ * Accepts ?locale= to filter by language (defaults to site's defaultLocale).
  */
 app.get('/', async (c) => {
   const db = getDb();
@@ -26,10 +28,15 @@ app.get('/', async (c) => {
   const sortParam = c.req.query('sort') || 'published_at:desc';
   const limit = Math.min(parseInt(c.req.query('limit') || '20', 10), 50);
   const offset = parseInt(c.req.query('offset') || '0', 10);
+  const localeParam = c.req.query('locale');
+
+  const config = await loadConfig();
+  const locale = localeParam || config.defaultLocale;
 
   const now = new Date().toISOString();
   const conditions: ReturnType<typeof eq>[] = [
     eq(pages.status, 'published'),
+    eq(pages.locale, locale),
     sql`(${pages.scheduledAt} IS NULL OR ${pages.scheduledAt} <= ${now})`,
   ];
 
@@ -101,6 +108,7 @@ app.get('/', async (c) => {
       slug: pages.slug,
       status: pages.status,
       fields: pages.fields,
+      locale: pages.locale,
       createdAt: pages.createdAt,
       updatedAt: pages.updatedAt,
       publishedAt: pages.publishedAt,
@@ -146,6 +154,7 @@ app.get('/', async (c) => {
     title: row.title,
     slug: row.slug,
     status: row.status,
+    locale: row.locale,
     fields: row.fields,
     terms: termsMap[row.id] || [],
     meta: {
@@ -164,8 +173,12 @@ app.get('/', async (c) => {
 app.get('/:slug{.+}', async (c) => {
   const db = getDb();
   const slug = c.req.param('slug');
+  const localeParam = c.req.query('locale');
 
-  const cacheKey = `pages:${slug}`;
+  const config = await loadConfig();
+  const locale = localeParam || config.defaultLocale;
+
+  const cacheKey = `pages:${locale}:${slug}`;
   const cached = cacheGet<object>(cacheKey);
   if (cached) return c.json(cached);
 
@@ -178,6 +191,8 @@ app.get('/:slug{.+}', async (c) => {
       title: pages.title,
       slug: pages.slug,
       status: pages.status,
+      locale: pages.locale,
+      translationGroupId: pages.translationGroupId,
       fields: pages.fields,
       metaTitle: pages.metaTitle,
       metaDescription: pages.metaDescription,
@@ -192,6 +207,7 @@ app.get('/:slug{.+}', async (c) => {
     .innerJoin(contentTypes, eq(pages.typeId, contentTypes.id))
     .where(and(
       eq(pages.slug, slug),
+      eq(pages.locale, locale),
       eq(pages.status, 'published'),
       sql`(${pages.scheduledAt} IS NULL OR ${pages.scheduledAt} <= ${new Date().toISOString()})`,
     ))
@@ -266,12 +282,29 @@ app.get('/:slug{.+}', async (c) => {
       and(eq(contentTerms.entityType, 'page'), eq(contentTerms.entityId, page.id))
     );
 
+  // Fetch sibling translations if page is in a translation group
+  let translations: Array<{ locale: string; slug: string; title: string; id: number }> = [];
+  if (page.translationGroupId) {
+    const siblings = await db
+      .select({ id: pages.id, locale: pages.locale, slug: pages.slug, title: pages.title })
+      .from(pages)
+      .where(and(
+        eq(pages.translationGroupId, page.translationGroupId),
+        eq(pages.status, 'published'),
+        sql`${pages.id} != ${page.id}`,
+      ));
+    translations = siblings;
+  }
+
   const data = {
     id: page.id,
     type: page.typeSlug,
     title: page.title,
     slug: page.slug,
     status: page.status,
+    locale: page.locale,
+    translationGroupId: page.translationGroupId,
+    translations,
     fields: page.fields,
     terms: termRows.map((tr: typeof termRows[0]) => ({ taxonomy: tr.taxonomySlug, term: tr.termSlug, weight: tr.weight })),
     seo: {

--- a/packages/server/src/db/schema-pg/pages.ts
+++ b/packages/server/src/db/schema-pg/pages.ts
@@ -1,4 +1,4 @@
-import { pgTable, text, serial, integer, index, jsonb } from 'drizzle-orm/pg-core';
+import { pgTable, text, serial, integer, index, jsonb, uniqueIndex } from 'drizzle-orm/pg-core';
 import { contentTypes } from './content-types.ts';
 import { users } from './system.ts';
 
@@ -6,10 +6,12 @@ export const pages = pgTable('pages', {
   id: serial('id').primaryKey(),
   typeId: integer('type_id').notNull().references(() => contentTypes.id),
   title: text('title').notNull(),
-  slug: text('slug').notNull().unique(),
+  slug: text('slug').notNull(),
   status: text('status', { enum: ['draft', 'published', 'archived'] })
     .notNull()
     .default('draft'),
+  locale: text('locale').notNull().default('en'),
+  translationGroupId: text('translation_group_id'),
   fields: jsonb('fields').$type<Record<string, unknown>>(),
   createdAt: text('created_at').notNull(),
   updatedAt: text('updated_at').notNull(),
@@ -23,10 +25,13 @@ export const pages = pgTable('pages', {
   robots: text('robots'),
   createdBy: integer('created_by').references(() => users.id),
 }, (table) => [
+  uniqueIndex('pages_slug_locale_unique').on(table.slug, table.locale),
   index('idx_pages_slug').on(table.slug),
   index('idx_pages_type').on(table.typeId),
   index('idx_pages_status').on(table.status),
   index('idx_pages_type_status').on(table.typeId, table.status),
+  index('idx_pages_locale').on(table.locale),
+  index('idx_pages_translation_group').on(table.translationGroupId),
 ]);
 
 export const pageRevisions = pgTable('page_revisions', {
@@ -35,6 +40,7 @@ export const pageRevisions = pgTable('page_revisions', {
   title: text('title').notNull(),
   slug: text('slug').notNull(),
   status: text('status').notNull(),
+  locale: text('locale').notNull().default('en'),
   fields: jsonb('fields').$type<Record<string, unknown>>(),
   blocks: jsonb('blocks').$type<unknown[]>(),
   createdAt: text('created_at').notNull(),

--- a/packages/server/src/db/schema/pages.ts
+++ b/packages/server/src/db/schema/pages.ts
@@ -1,4 +1,4 @@
-import { sqliteTable, text, integer, index } from 'drizzle-orm/sqlite-core';
+import { sqliteTable, text, integer, index, uniqueIndex } from 'drizzle-orm/sqlite-core';
 import { contentTypes } from './content-types.ts';
 import { users } from './system.ts';
 
@@ -6,10 +6,12 @@ export const pages = sqliteTable('pages', {
   id: integer('id').primaryKey({ autoIncrement: true }),
   typeId: integer('type_id').notNull().references(() => contentTypes.id),
   title: text('title').notNull(),
-  slug: text('slug').notNull().unique(),
+  slug: text('slug').notNull(),
   status: text('status', { enum: ['draft', 'published', 'archived'] })
     .notNull()
     .default('draft'),
+  locale: text('locale').notNull().default('en'),
+  translationGroupId: text('translation_group_id'),
   fields: text('fields', { mode: 'json' }).$type<Record<string, unknown>>(),
   createdAt: text('created_at').notNull(),
   updatedAt: text('updated_at').notNull(),
@@ -23,10 +25,13 @@ export const pages = sqliteTable('pages', {
   robots: text('robots'),
   createdBy: integer('created_by').references(() => users.id),
 }, (table) => [
+  uniqueIndex('pages_slug_locale_unique').on(table.slug, table.locale),
   index('idx_pages_slug').on(table.slug),
   index('idx_pages_type').on(table.typeId),
   index('idx_pages_status').on(table.status),
   index('idx_pages_type_status').on(table.typeId, table.status),
+  index('idx_pages_locale').on(table.locale),
+  index('idx_pages_translation_group').on(table.translationGroupId),
 ]);
 
 export const pageRevisions = sqliteTable('page_revisions', {
@@ -35,6 +40,7 @@ export const pageRevisions = sqliteTable('page_revisions', {
   title: text('title').notNull(),
   slug: text('slug').notNull(),
   status: text('status').notNull(),
+  locale: text('locale').notNull().default('en'),
   fields: text('fields', { mode: 'json' }).$type<Record<string, unknown>>(),
   blocks: text('blocks', { mode: 'json' }).$type<unknown[]>(),
   note: text('note'),


### PR DESCRIPTION
## Summary

Page-level localization for WollyCMS. Each locale gets its own page linked by a translation group.

**Schema:**
- `locale` and `translationGroupId` columns on pages table
- Slug uniqueness changed from global to per-locale (compound index)
- Migration 0018 — safe on D1 (DROP INDEX + ALTER TABLE ADD, no table recreation)

**Config:**
- `defaultLocale` and `supportedLocales` in site config
- Public content config API now reads from database

**Content API:**
- `?locale=` param on page list and single page endpoints
- Single page response includes `translations` array (sibling pages)
- Cache keys scoped by locale

**Admin API:**
- Locale-scoped slug uniqueness checks
- `POST /pages/:id/translate` — create linked translation
- `GET /pages/:id/translations` — list siblings

**Admin UI:**
- Pages list: locale column + filter + create modal selector
- Page editor: locale badge, translations card with "Translate to..." buttons
- Settings: localization section with locale management

**Docs:**
- Full i18n docs page with setup, API, Astro integration examples, language switcher component

## Test plan
- [ ] Add `es` to supported locales in Settings, save
- [ ] Locale filter appears in pages list
- [ ] "Translate to ES" button appears in page editor sidebar
- [ ] Creating translation links pages and navigates to new draft
- [ ] Content API `?locale=es` filters correctly
- [ ] Existing sites with no locale config see no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)