### PR TITLE
feat: full-text search with SQLite FTS5

### DIFF
--- a/packages/server/drizzle/0019_fts_search.sql
+++ b/packages/server/drizzle/0019_fts_search.sql
@@ -1,0 +1,10 @@
+-- Full-text search index for pages (SQLite FTS5)
+-- D1 supports FTS5 virtual tables
+CREATE VIRTUAL TABLE IF NOT EXISTS pages_fts USING fts5(
+  page_id UNINDEXED,
+  title,
+  slug,
+  body,
+  meta_description,
+  tokenize='porter unicode61'
+);

--- a/packages/server/drizzle/meta/_journal.json
+++ b/packages/server/drizzle/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1774200000000,
       "tag": "0018_i18n",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "6",
+      "when": 1774210000000,
+      "tag": "0019_fts_search",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/server/src/api/admin/pages.ts
+++ b/packages/server/src/api/admin/pages.ts
@@ -14,6 +14,7 @@ import pageTermsRouter from './page-terms.js';
 import { requireRole } from '../../auth/rbac.js';
 import { loadConfig } from './config.js';
 import { hooks } from '../../hooks.js';
+import { indexPage, deindexPage, extractPageBody } from '../../search-index.js';
 
 /** Validate a workflow status transition. Returns error message or null if valid. */
 async function validateTransition(
@@ -327,6 +328,9 @@ app.post('/', async (c) => {
   // Lifecycle hook: afterCreate
   hooks.runAfter('afterCreate', { entity: row as unknown as Record<string, unknown>, id: row.id, user: { id: payload.sub, email: payload.email, role: payload.role } });
 
+  // Index for full-text search (best-effort, don't block response)
+  indexPage(row.id, row.title, slug, '', row.metaDescription || null).catch(() => {});
+
   return c.json({ data: row }, 201);
 });
 
@@ -604,6 +608,16 @@ app.put('/:id', async (c) => {
   // Lifecycle hook: afterUpdate
   hooks.runAfter('afterUpdate', { entity: updated as unknown as Record<string, unknown>, id, user: { id: payload.sub, email: payload.email, role: payload.role } });
 
+  // Re-index for full-text search (fetch block content for body text)
+  db.select({ fields: blocks.fields })
+    .from(pageBlocks)
+    .innerJoin(blocks, eq(pageBlocks.blockId, blocks.id))
+    .where(eq(pageBlocks.pageId, id))
+    .then((blockRows: Array<{ fields: Record<string, unknown> | null }>) => {
+      const bx = blockRows.map((r: { fields: Record<string, unknown> | null }) => ({ fields: (r.fields || {}) as Record<string, unknown> }));
+      return indexPage(id, updated.title, updated.slug, extractPageBody(bx), updated.metaDescription || null);
+    }).catch(() => {});
+
   cacheInvalidate('pages:');
   clearOgCache();
   return c.json({ data: updated });
@@ -631,6 +645,9 @@ app.delete('/:id', async (c) => {
 
   // Lifecycle hook: afterDelete
   hooks.runAfter('afterDelete', { entity: existing as unknown as Record<string, unknown>, id, user: { id: payload.sub, email: payload.email, role: payload.role } });
+
+  // Remove from search index
+  deindexPage(id).catch(() => {});
 
   return c.json({ data: { deleted: true } });
 });

--- a/packages/server/src/api/content/search.ts
+++ b/packages/server/src/api/content/search.ts
@@ -1,8 +1,10 @@
 import { Hono } from 'hono';
-import { eq, and, sql, like, or, desc } from 'drizzle-orm';
+import { eq, and, sql, like, or, desc, inArray } from 'drizzle-orm';
 import { getDb } from '../../db/index.js';
-import { pages, contentTypes, blocks, blockTypes, pageBlocks } from '../../db/schema/index.js';
+import { pages, contentTypes } from '../../db/schema/index.js';
 import { cacheGet, cacheSet } from '../../cache.js';
+import { ftsSearch } from '../../search-index.js';
+import { loadConfig } from '../admin/config.js';
 
 const app = new Hono();
 
@@ -11,8 +13,8 @@ function escapeLike(s: string): string {
 }
 
 /**
- * GET /?q=<query> — Search published pages by title, slug, and block content.
- * Returns matching pages with highlighted context.
+ * GET /?q=<query> — Search published pages.
+ * Uses FTS5 full-text search when available, falls back to LIKE matching.
  */
 app.get('/', async (c) => {
   const q = c.req.query('q')?.trim();
@@ -22,51 +24,104 @@ app.get('/', async (c) => {
 
   const limit = Math.min(parseInt(c.req.query('limit') || '20', 10), 50);
   const typeFilter = c.req.query('type');
+  const localeParam = c.req.query('locale');
 
-  const cacheKey = `pages:search:${q}:${limit}:${typeFilter || ''}`;
+  const config = await loadConfig();
+  const locale = localeParam || config.defaultLocale;
+
+  const cacheKey = `pages:search:${locale}:${q}:${limit}:${typeFilter || ''}`;
   const cached = cacheGet<object>(cacheKey);
   if (cached) return c.json(cached);
 
   const db = getDb();
-  const now = new Date().toISOString();
-  const term = `%${escapeLike(q)}%`;
 
-  const conditions = [
-    eq(pages.status, 'published'),
-    sql`(${pages.scheduledAt} IS NULL OR ${pages.scheduledAt} <= ${now})`,
-    or(
-      like(pages.title, term),
-      like(pages.slug, term),
-    ),
-  ];
+  // Try FTS5 first
+  const ftsResults = await ftsSearch(q, limit * 2); // fetch extra to allow filtering
 
-  if (typeFilter) {
-    const [typeRow] = await db.select({ id: contentTypes.id }).from(contentTypes).where(eq(contentTypes.slug, typeFilter)).limit(1);
-    if (typeRow) conditions.push(eq(pages.typeId, typeRow.id));
+  type SearchRow = { id: number; typeSlug: string; title: string; slug: string; locale: string; metaDescription: string | null; updatedAt: string; publishedAt: string | null };
+  let rows: SearchRow[];
+
+  if (ftsResults.length > 0) {
+    // FTS matched — fetch page data for matched IDs
+    const matchedIds = ftsResults.map((r) => r.pageId);
+    const now = new Date().toISOString();
+
+    const conditions = [
+      eq(pages.status, 'published'),
+      eq(pages.locale, locale),
+      sql`(${pages.scheduledAt} IS NULL OR ${pages.scheduledAt} <= ${now})`,
+      sql`${pages.id} IN (${sql.raw(matchedIds.join(','))})`,
+    ];
+
+    if (typeFilter) {
+      const [typeRow] = await db.select({ id: contentTypes.id }).from(contentTypes).where(eq(contentTypes.slug, typeFilter)).limit(1);
+      if (typeRow) conditions.push(eq(pages.typeId, typeRow.id));
+    }
+
+    rows = await db
+      .select({
+        id: pages.id,
+        typeSlug: contentTypes.slug,
+        title: pages.title,
+        slug: pages.slug,
+        locale: pages.locale,
+        metaDescription: pages.metaDescription,
+        updatedAt: pages.updatedAt,
+        publishedAt: pages.publishedAt,
+      })
+      .from(pages)
+      .innerJoin(contentTypes, eq(pages.typeId, contentTypes.id))
+      .where(and(...conditions))
+      .limit(limit);
+
+    // Sort by FTS rank
+    const rankMap = new Map(ftsResults.map((r) => [r.pageId, r.rank]));
+    rows.sort((a: typeof rows[0], b: typeof rows[0]) => (rankMap.get(a.id) ?? 0) - (rankMap.get(b.id) ?? 0));
+  } else {
+    // Fallback: LIKE matching on title and slug
+    const now = new Date().toISOString();
+    const term = `%${escapeLike(q)}%`;
+
+    const conditions = [
+      eq(pages.status, 'published'),
+      eq(pages.locale, locale),
+      sql`(${pages.scheduledAt} IS NULL OR ${pages.scheduledAt} <= ${now})`,
+      or(
+        like(pages.title, term),
+        like(pages.slug, term),
+        like(pages.metaDescription, term),
+      ),
+    ];
+
+    if (typeFilter) {
+      const [typeRow] = await db.select({ id: contentTypes.id }).from(contentTypes).where(eq(contentTypes.slug, typeFilter)).limit(1);
+      if (typeRow) conditions.push(eq(pages.typeId, typeRow.id));
+    }
+
+    rows = await db
+      .select({
+        id: pages.id,
+        typeSlug: contentTypes.slug,
+        title: pages.title,
+        slug: pages.slug,
+        locale: pages.locale,
+        metaDescription: pages.metaDescription,
+        updatedAt: pages.updatedAt,
+        publishedAt: pages.publishedAt,
+      })
+      .from(pages)
+      .innerJoin(contentTypes, eq(pages.typeId, contentTypes.id))
+      .where(and(...conditions))
+      .orderBy(desc(pages.publishedAt))
+      .limit(limit);
   }
-
-  const rows = await db
-    .select({
-      id: pages.id,
-      typeSlug: contentTypes.slug,
-      title: pages.title,
-      slug: pages.slug,
-      fields: pages.fields,
-      metaDescription: pages.metaDescription,
-      updatedAt: pages.updatedAt,
-      publishedAt: pages.publishedAt,
-    })
-    .from(pages)
-    .innerJoin(contentTypes, eq(pages.typeId, contentTypes.id))
-    .where(and(...conditions))
-    .orderBy(desc(pages.publishedAt))
-    .limit(limit);
 
   const data = rows.map((r: typeof rows[0]) => ({
     id: r.id,
     type: r.typeSlug,
     title: r.title,
     slug: r.slug,
+    locale: r.locale,
     description: r.metaDescription || null,
     meta: {
       updated_at: r.updatedAt,
@@ -75,7 +130,7 @@ app.get('/', async (c) => {
   }));
 
   const response = { data, meta: { total: data.length, query: q } };
-  cacheSet(cacheKey, response, 15_000); // 15s cache for search
+  cacheSet(cacheKey, response, 15_000);
   return c.json(response);
 });
 

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -261,6 +261,16 @@ async function main() {
       break;
     }
 
+    case 'search:rebuild': {
+      const { getDb: getDbForSearch } = await import('./db/index.js');
+      const { rebuildSearchIndex } = await import('./search-index.js');
+      getDbForSearch();
+      console.log('Rebuilding search index...');
+      const count = await rebuildSearchIndex();
+      console.log(`Indexed ${count} published pages.`);
+      break;
+    }
+
     default:
       console.log(`WollyCMS CLI v0.1.0
 
@@ -274,6 +284,7 @@ Commands:
   import <file>        Import data from a JSON backup file
   types generate       Generate TypeScript types from CMS schemas
   og:generate          Generate OG images for published pages
+  search:rebuild       Rebuild full-text search index
   health               Check server health status
 
 Examples:
@@ -285,7 +296,8 @@ Examples:
   wolly og:generate                    # pages missing OG images
   wolly og:generate --force            # regenerate all
   wolly og:generate --type=blog        # specific content type
-  wolly og:generate --dry-run          # preview without generating`);
+  wolly og:generate --dry-run          # preview without generating
+  wolly search:rebuild                 # rebuild FTS index`);
       if (command) {
         console.error(`\nUnknown command: ${command}`);
         process.exit(1);

--- a/packages/server/src/search-index.ts
+++ b/packages/server/src/search-index.ts
@@ -1,0 +1,145 @@
+/**
+ * Full-text search indexing for pages.
+ * Uses SQLite FTS5 on D1/SQLite, stubs for PostgreSQL.
+ */
+import { sql } from 'drizzle-orm';
+import { getDb } from './db/index.js';
+import { getDialect } from './env.js';
+
+/** Extract plain text from TipTap JSON content (recursive). */
+export function extractText(node: unknown): string {
+  if (!node || typeof node !== 'object') return '';
+
+  const n = node as Record<string, unknown>;
+
+  // Text node
+  if (n.type === 'text' && typeof n.text === 'string') {
+    return n.text;
+  }
+
+  // Recurse into children
+  if (Array.isArray(n.content)) {
+    return n.content.map(extractText).join(' ');
+  }
+
+  return '';
+}
+
+/** Extract all searchable text from a page's blocks. */
+export function extractPageBody(
+  blocks: Array<{ fields: Record<string, unknown> }>,
+): string {
+  const parts: string[] = [];
+
+  for (const block of blocks) {
+    if (!block.fields) continue;
+    for (const [, value] of Object.entries(block.fields)) {
+      if (typeof value === 'string') {
+        // Plain text or HTML — strip tags
+        parts.push(value.replace(/<[^>]*>/g, ' '));
+      } else if (value && typeof value === 'object') {
+        // TipTap JSON
+        parts.push(extractText(value));
+      }
+    }
+  }
+
+  return parts.join(' ').replace(/\s+/g, ' ').trim();
+}
+
+/** Index a page in the FTS table. Idempotent (deletes then inserts). */
+export async function indexPage(
+  pageId: number,
+  title: string,
+  slug: string,
+  body: string,
+  metaDescription: string | null,
+): Promise<void> {
+  if (getDialect() === 'postgresql') return;
+
+  const db = getDb();
+  try {
+    await db.run(sql`DELETE FROM pages_fts WHERE page_id = ${pageId}`);
+    await db.run(sql`INSERT INTO pages_fts (page_id, title, slug, body, meta_description)
+      VALUES (${pageId}, ${title}, ${slug}, ${body}, ${metaDescription || ''})`);
+  } catch {
+    // FTS table may not exist yet — skip silently
+  }
+}
+
+/** Remove a page from the FTS index. */
+export async function deindexPage(pageId: number): Promise<void> {
+  if (getDialect() === 'postgresql') return;
+
+  const db = getDb();
+  try {
+    await db.run(sql`DELETE FROM pages_fts WHERE page_id = ${pageId}`);
+  } catch {
+    // FTS table may not exist — skip
+  }
+}
+
+/** Full-text search using FTS5 MATCH with BM25 ranking. */
+export async function ftsSearch(
+  query: string,
+  limit: number,
+): Promise<Array<{ pageId: number; rank: number }>> {
+  if (getDialect() === 'postgresql') return [];
+
+  const db = getDb();
+  try {
+    const ftsQuery = query
+      .trim()
+      .split(/\s+/)
+      .map((w) => `"${w.replace(/"/g, '')}"*`)
+      .join(' ');
+
+    const result = await db.run(
+      sql`SELECT page_id, rank FROM pages_fts WHERE pages_fts MATCH ${ftsQuery} ORDER BY rank LIMIT ${limit}`,
+    );
+    const rows = (result as unknown as { rows: Array<{ page_id: number; rank: number }> }).rows
+      ?? (result as unknown as Array<{ page_id: number; rank: number }>);
+    if (!Array.isArray(rows)) return [];
+    return rows.map((r: { page_id: number; rank: number }) => ({ pageId: r.page_id, rank: r.rank }));
+  } catch {
+    return [];
+  }
+}
+
+/** Rebuild the entire FTS index from all published pages. */
+export async function rebuildSearchIndex(): Promise<number> {
+  if (getDialect() === 'postgresql') return 0;
+
+  const db = getDb();
+  try {
+    await db.run(sql`DELETE FROM pages_fts`);
+
+    const result = await db.run(
+      sql`SELECT id, title, slug, meta_description FROM pages WHERE status = 'published'`,
+    );
+    const pageRows = (result as unknown as { rows: Array<Record<string, unknown>> }).rows
+      ?? (result as unknown as Array<Record<string, unknown>>);
+    if (!Array.isArray(pageRows)) return 0;
+
+    for (const page of pageRows) {
+      const blockResult = await db.run(
+        sql`SELECT b.fields FROM page_blocks pb
+            INNER JOIN blocks b ON pb.block_id = b.id
+            WHERE pb.page_id = ${page.id}`,
+      );
+      const blockRows = (blockResult as unknown as { rows: Array<{ fields: string }> }).rows
+        ?? (blockResult as unknown as Array<{ fields: string }>);
+      const blocks = (Array.isArray(blockRows) ? blockRows : []).map((r: { fields: string }) => ({
+        fields: typeof r.fields === 'string' ? JSON.parse(r.fields) : r.fields,
+      }));
+      const body = extractPageBody(blocks);
+
+      await db.run(sql`INSERT INTO pages_fts (page_id, title, slug, body, meta_description)
+        VALUES (${page.id}, ${String(page.title)}, ${String(page.slug)}, ${body}, ${String(page.meta_description || '')})`);
+    }
+
+    return pageRows.length;
+  } catch {
+    return 0;
+  }
+}


### PR DESCRIPTION
## Summary

Full-text search upgrade using SQLite FTS5 with Porter stemming.

- FTS5 virtual table indexes page titles, slugs, block body text, and meta descriptions
- Search uses MATCH with BM25 relevance ranking, falls back to LIKE
- Body text extracted from TipTap JSON and HTML blocks
- Index kept in sync on page create/update/delete
- Locale-aware search
- CLI: `wolly search:rebuild` to rebuild the index
- PostgreSQL stubbed for future enhancement

## Test plan
- [ ] All 204 existing tests pass
- [ ] Search finds pages by content words (not just title substring)
- [ ] FTS gracefully falls back if virtual table doesn't exist yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)