### PR TITLE
fix: settings page cleanup + sidebar reorganization

### DIFF
--- a/packages/admin/src/routes/+layout.svelte
+++ b/packages/admin/src/routes/+layout.svelte
@@ -129,8 +129,13 @@
         { href: '/api-keys', label: 'API Keys', icon: KeyRound },
         { href: '/tracking-scripts', label: 'Tracking', icon: Code },
         { href: '/audit-logs', label: 'Audit Log', icon: ScrollText },
-        { href: '/account', label: 'Account', icon: Shield },
         { href: '/settings', label: 'Settings', icon: Settings },
+      ],
+    },
+    {
+      label: 'Account',
+      items: [
+        { href: '/account', label: 'My Account', icon: Shield },
       ],
     },
   ];

--- a/packages/admin/src/routes/settings/+page.svelte
+++ b/packages/admin/src/routes/settings/+page.svelte
@@ -6,15 +6,15 @@
   let config = $state<any>(null);
   let error = $state('');
   let saving = $state(false);
-  let importing = $state(false);
 
   onMount(async () => {
     try {
       const res = await api.get<{ data: any }>('/config');
       config = res.data;
-      // Ensure nested objects exist for binding
       if (!config.ai) config.ai = { provider: '', apiKey: '', model: '', baseUrl: '' };
       if (!config.workflow) config.workflow = { stages: [] };
+      if (!config.footer) config.footer = { text: '' };
+      if (!config.social) config.social = { facebook: null, twitter: null, instagram: null };
     } catch (err: any) { error = err.message; }
   });
 
@@ -24,6 +24,8 @@
     try {
       const res = await api.put<{ data: any }>('/config', config);
       config = res.data;
+      if (!config.ai) config.ai = { provider: '', apiKey: '', model: '', baseUrl: '' };
+      if (!config.workflow) config.workflow = { stages: [] };
       toast.success('Settings saved.');
     } catch (err: any) { error = err.message; }
     finally { saving = false; }
@@ -40,8 +42,10 @@
 {#if error}<div class="alert alert-error">{error}</div>{/if}
 
 {#if config}
-  <div class="card" style="max-width: 600px;">
-    <h2 style="font-size: 1.1rem; margin-bottom: 1rem;">General</h2>
+  <!-- Site -->
+  <div class="card settings-card">
+    <h2>Site</h2>
+    <p class="section-hint">Public site info — available to your frontend via <code class="mono">/api/content/config</code>.</p>
     <div class="form-group">
       <label>Site Name</label>
       <input class="form-control" bind:value={config.siteName} />
@@ -54,25 +58,34 @@
       <label>Footer Text</label>
       <input class="form-control" bind:value={config.footer.text} />
     </div>
+    <div class="form-group">
+      <label>Social Links</label>
+      <div class="social-grid">
+        <input class="form-control" bind:value={config.social.facebook} placeholder="Facebook URL" />
+        <input class="form-control" bind:value={config.social.twitter} placeholder="Twitter / X URL" />
+        <input class="form-control" bind:value={config.social.instagram} placeholder="Instagram URL" />
+      </div>
+      <p class="field-hint">Optional — available to your frontend for footer/header social icons.</p>
+    </div>
+  </div>
 
-    <hr style="margin: 1.5rem 0; border: none; border-top: 1px solid var(--c-border);" />
-    <h2 style="font-size: 1.1rem; margin-bottom: 1rem;">Admin Branding</h2>
+  <!-- Admin Branding -->
+  <div class="card settings-card">
+    <h2>Admin Branding</h2>
     <div class="form-group">
       <label>Admin Panel Name</label>
       <input class="form-control" bind:value={config.adminBrandName} placeholder="WollyCMS" />
-      <p style="font-size: 0.8rem; color: var(--c-text-light); margin-top: 0.25rem;">
-        Displayed in the top-left corner of the admin panel. Leave empty to use "WollyCMS".
-      </p>
+      <p class="field-hint">Displayed in the sidebar header. Leave empty to use "WollyCMS".</p>
     </div>
+  </div>
 
-    <hr style="margin: 1.5rem 0; border: none; border-top: 1px solid var(--c-border);" />
-    <h2 style="font-size: 1.1rem; margin-bottom: 1rem;">AI Provider</h2>
-    <p style="font-size: 0.85rem; color: var(--c-text-light); margin-bottom: 0.75rem;">
-      Connect an AI model for content suggestions, alt text generation, and SEO descriptions.
-    </p>
+  <!-- AI Provider -->
+  <div class="card settings-card">
+    <h2>AI Provider</h2>
+    <p class="section-hint">Connect an AI model for content suggestions, alt text generation, and SEO descriptions.</p>
     <div class="form-group">
       <label>Provider</label>
-      <select class="form-control" style="max-width: 200px;" bind:value={config.ai.provider}>
+      <select class="form-control" style="max-width: 220px;" bind:value={config.ai.provider}>
         <option value="">None (disabled)</option>
         <option value="openai">OpenAI</option>
         <option value="anthropic">Anthropic (Claude)</option>
@@ -104,30 +117,30 @@
         </div>
       {/if}
     {/if}
+  </div>
 
-    <hr style="margin: 1.5rem 0; border: none; border-top: 1px solid var(--c-border);" />
-    <h2 style="font-size: 1.1rem; margin-bottom: 1rem;">Localization</h2>
+  <!-- Localization -->
+  <div class="card settings-card">
+    <h2>Localization</h2>
     <div class="form-group">
       <label>Default Locale</label>
-      <select class="form-control" bind:value={config.defaultLocale} style="max-width: 200px;">
+      <select class="form-control" style="max-width: 200px;" bind:value={config.defaultLocale}>
         {#each (config.supportedLocales || ['en']) as loc}
           <option value={loc}>{loc}</option>
         {/each}
       </select>
-      <p style="font-size: 0.8rem; color: var(--c-text-light); margin-top: 0.25rem;">
-        Used when no locale is specified in API requests.
-      </p>
+      <p class="field-hint">Used when no locale is specified in API requests.</p>
     </div>
     <div class="form-group">
       <label>Supported Locales</label>
-      <div style="display: flex; flex-wrap: wrap; gap: 0.35rem; margin-bottom: 0.5rem;">
+      <div class="locale-tags">
         {#each (config.supportedLocales || ['en']) as loc, i}
-          <span style="display: inline-flex; align-items: center; gap: 0.25rem; padding: 0.25rem 0.5rem; background: var(--c-bg-subtle); border-radius: var(--radius); font-size: 0.85rem;">
+          <span class="locale-tag">
             {loc}
             {#if config.supportedLocales.length > 1}
               <button
                 type="button"
-                style="background: none; border: none; cursor: pointer; color: var(--c-text-light); font-size: 0.75rem; padding: 0;"
+                class="locale-tag-remove"
                 onclick={() => {
                   config.supportedLocales = config.supportedLocales.filter((_: string, j: number) => j !== i);
                   if (config.defaultLocale === loc) config.defaultLocale = config.supportedLocales[0];
@@ -155,20 +168,20 @@
             }
           }}
         />
-        <span style="font-size: 0.75rem; color: var(--c-text-light);">Press Enter to add</span>
+        <span class="field-hint" style="margin-top: 0;">Press Enter to add</span>
       </div>
     </div>
+  </div>
 
-    <hr style="margin: 1.5rem 0; border: none; border-top: 1px solid var(--c-border);" />
-    <h2 style="font-size: 1.1rem; margin-bottom: 1rem;">Workflow</h2>
-    <p style="font-size: 0.85rem; color: var(--c-text-light); margin-bottom: 0.75rem;">
-      Define the stages content goes through before publishing. Each stage has allowed transitions and optional role requirements.
-    </p>
+  <!-- Workflow -->
+  <div class="card settings-card">
+    <h2>Workflow</h2>
+    <p class="section-hint">Define the stages content goes through before publishing.</p>
     {#each (config.workflow?.stages || []) as stage, i}
-      <div style="display: flex; gap: 0.5rem; align-items: center; margin-bottom: 0.5rem; padding: 0.5rem; background: var(--c-bg-subtle); border-radius: var(--radius);">
+      <div class="workflow-stage">
         <input class="form-control" style="max-width: 100px; font-size: 0.85rem;" bind:value={stage.slug} placeholder="slug" />
         <input class="form-control" style="max-width: 120px; font-size: 0.85rem;" bind:value={stage.label} placeholder="Label" />
-        <input type="color" style="width: 32px; height: 32px; border: none; cursor: pointer; border-radius: 4px;" bind:value={stage.color} />
+        <input type="color" class="color-picker" bind:value={stage.color} />
         <select class="form-control" style="max-width: 100px; font-size: 0.85rem;" bind:value={stage.requiredRole}>
           <option value={null}>Any role</option>
           <option value="editor">Editor</option>
@@ -198,55 +211,90 @@
         ];
       }}
     >+ Add Stage</button>
-    <p style="font-size: 0.75rem; color: var(--c-text-light); margin-top: 0.5rem;">
-      "draft" and "published" are required stages. Add custom stages between them (e.g., In Review, Approved). Transition rules are configured via the API.
-    </p>
-
-    <hr style="margin: 1.5rem 0; border: none; border-top: 1px solid var(--c-border);" />
-    <h2 style="font-size: 1.1rem; margin-bottom: 1rem;">Social Links</h2>
-    <div class="form-group">
-      <label>Facebook</label>
-      <input class="form-control" bind:value={config.social.facebook} placeholder="https://facebook.com/..." />
-    </div>
-    <div class="form-group">
-      <label>Twitter / X</label>
-      <input class="form-control" bind:value={config.social.twitter} placeholder="https://x.com/..." />
-    </div>
-    <div class="form-group">
-      <label>Instagram</label>
-      <input class="form-control" bind:value={config.social.instagram} placeholder="https://instagram.com/..." />
-    </div>
-  </div>
-
-  <div class="card" style="max-width: 600px; margin-top: 1.5rem;">
-    <h2 style="font-size: 1.1rem; margin-bottom: 1rem;">Data Management</h2>
-    <div style="display: flex; gap: 0.75rem; flex-wrap: wrap;">
-      <button class="btn btn-outline" onclick={() => window.open('/api/admin/export', '_blank')}>Export All Content (JSON)</button>
-      <label class="btn btn-outline" style="cursor: pointer;">
-        {importing ? 'Importing...' : 'Import Content (JSON)'}
-        <input type="file" accept=".json" style="display: none;" onchange={async (e) => {
-          const file = (e.target as HTMLInputElement).files?.[0];
-          if (!file) return;
-          importing = true;
-          error = '';
-          try {
-            const text = await file.text();
-            const data = JSON.parse(text);
-            const res = await api.post<{ data: any }>('/import', data);
-            const stats = res.data.stats;
-            const summary = Object.entries(stats).map(([k, v]) => `${k}: ${v}`).join(', ');
-            toast.success(`Import complete. ${summary}`);
-          } catch (err: any) {
-            error = err.message || 'Import failed';
-          } finally {
-            importing = false;
-            (e.target as HTMLInputElement).value = '';
-          }
-        }} />
-      </label>
-    </div>
-    <p style="font-size: 0.8rem; color: var(--c-text-light); margin-top: 0.5rem;">
-      Export downloads all pages, blocks, menus, taxonomies, and redirects. Import skips existing records (no duplicates).
+    <p class="field-hint" style="margin-top: 0.5rem;">
+      "draft" and "published" are required. Add custom stages between them (e.g., In Review, Approved).
     </p>
   </div>
 {/if}
+
+<style>
+  .settings-card {
+    max-width: 600px;
+    margin-bottom: 1.25rem;
+  }
+
+  .settings-card h2 {
+    font-size: 1.05rem;
+    margin-bottom: 0.75rem;
+  }
+
+  .section-hint {
+    font-size: 0.85rem;
+    color: var(--c-text-light);
+    margin-bottom: 1rem;
+  }
+
+  .section-hint code {
+    font-size: 0.8rem;
+    padding: 0.1rem 0.3rem;
+    background: var(--c-bg-subtle);
+    border-radius: 3px;
+  }
+
+  .field-hint {
+    font-size: 0.8rem;
+    color: var(--c-text-light);
+    margin-top: 0.25rem;
+  }
+
+  .social-grid {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+  }
+
+  .locale-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .locale-tag {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.25rem 0.5rem;
+    background: var(--c-bg-subtle);
+    border-radius: var(--radius);
+    font-size: 0.85rem;
+  }
+
+  .locale-tag-remove {
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--c-text-light);
+    font-size: 0.75rem;
+    padding: 0;
+  }
+
+  .workflow-stage {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    margin-bottom: 0.5rem;
+    padding: 0.5rem;
+    background: var(--c-bg-subtle);
+    border-radius: var(--radius);
+  }
+
+  .color-picker {
+    width: 32px;
+    height: 32px;
+    border: none;
+    cursor: pointer;
+    border-radius: 4px;
+    padding: 0;
+  }
+</style>


### PR DESCRIPTION
## Summary

- Settings: renamed General→Site, folded social links in, removed data management, each section in own card
- Sidebar: moved Account to own section at bottom, cleaned up System

🤖 Generated with [Claude Code](https://claude.com/claude-code)