### PR TITLE
feat: 5 starter templates + create-wolly --template support

### DIFF
--- a/packages/create-wolly/src/index.js
+++ b/packages/create-wolly/src/index.js
@@ -9,10 +9,25 @@ import { createInterface } from 'readline';
 const rl = createInterface({ input: process.stdin, output: process.stdout });
 const ask = (q) => new Promise((resolve) => rl.question(q, resolve));
 
+const TEMPLATES = ['blog', 'marketing', 'wordpress', 'drupal', 'college'];
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  let name = '';
+  let template = '';
+  for (const arg of args) {
+    if (arg.startsWith('--template=')) template = arg.split('=')[1];
+    else if (arg.startsWith('--template')) template = args[args.indexOf(arg) + 1] || '';
+    else if (!arg.startsWith('-')) name = name || arg;
+  }
+  return { name, template };
+}
+
 async function main() {
   console.log('\n  🚀 Create WollyCMS Project\n');
 
-  const projectName = process.argv[2] || await ask('  Project name: ');
+  const parsed = parseArgs();
+  const projectName = parsed.name || await ask('  Project name: ');
   if (!projectName) {
     console.error('  Project name is required.');
     process.exit(1);
@@ -26,6 +41,16 @@ async function main() {
 
   const siteName = await ask(`  Site name [${projectName}]: `) || projectName;
   const port = await ask('  API port [4321]: ') || '4321';
+
+  let template = parsed.template;
+  if (!template) {
+    console.log(`\n  Available templates: ${TEMPLATES.join(', ')}`);
+    template = await ask('  Template (or press Enter to skip): ') || '';
+  }
+  if (template && !TEMPLATES.includes(template)) {
+    console.error(`  Unknown template: "${template}". Available: ${TEMPLATES.join(', ')}`);
+    process.exit(1);
+  }
 
   rl.close();
 
@@ -150,6 +175,35 @@ docker compose up -d
 Edit \`.env\` to configure. See \`.env.example\` for all options.
 `);
 
+  // Copy template seed file if selected
+  if (template) {
+    try {
+      const { fileURLToPath } = await import('url');
+      const { dirname: dirn } = await import('path');
+      const { copyFileSync } = await import('fs');
+      // Try to find template seed.json relative to this script or in the installed package
+      const scriptDir = dirn(fileURLToPath(import.meta.url));
+      const possiblePaths = [
+        join(scriptDir, '..', '..', '..', 'templates', template, 'seed.json'),
+        join(scriptDir, '..', 'templates', template, 'seed.json'),
+      ];
+      let copied = false;
+      for (const seedPath of possiblePaths) {
+        if (existsSync(seedPath)) {
+          copyFileSync(seedPath, join(projectDir, 'seed.json'));
+          copied = true;
+          break;
+        }
+      }
+      if (!copied) {
+        console.log(`  Template "${template}" seed file not found locally.`);
+        console.log(`  Download it from: https://github.com/wollycms/wollycms/tree/main/templates/${template}/seed.json`);
+      }
+    } catch {
+      console.log(`  Could not copy template seed file.`);
+    }
+  }
+
   console.log('  Created project files:');
   console.log('    package.json');
   console.log('    .env');
@@ -157,6 +211,7 @@ Edit \`.env\` to configure. See \`.env.example\` for all options.
   console.log('    .gitignore');
   console.log('    docker-compose.yml');
   console.log('    README.md');
+  if (template) console.log('    seed.json');
   console.log('');
 
   // Install dependencies
@@ -167,13 +222,14 @@ Edit \`.env\` to configure. See \`.env.example\` for all options.
     console.log('\n  npm install failed — run it manually after setup.');
   }
 
+  const seedStep = template ? `    wolly import seed.json    # Import ${template} template content` : '    npm run seed              # Sample content';
   console.log(`
-  ✅ Project created!
+  ✅ Project created!${template ? ` (${template} template)` : ''}
 
   Next steps:
     cd ${projectName}
     npm run migrate
-    npm run seed
+${seedStep}
     npm run dev
 
   Then open http://localhost:${port}

--- a/templates/blog/README.md
+++ b/templates/blog/README.md
@@ -1,0 +1,39 @@
+# WollyCMS Blog Template
+
+A personal or company blog with posts, tags, and a clean content structure.
+
+## What's included
+
+- 2 content types, 4 block types, 5 sample pages
+- Pre-configured taxonomy (tags: Technology, Tutorial, News, Opinion)
+- Main navigation menu (Home, Blog, About)
+- 3 sample blog posts with hero banners and rich text content
+- Ready to customize
+
+## Quick start
+
+```bash
+npx create-wolly my-site --template blog
+cd my-site
+wolly migrate
+wolly import templates/blog/seed.json
+wolly start
+```
+
+## Content types
+
+| Content Type | Slug | Regions |
+|-------------|------|---------|
+| Blog Post | `blog_post` | hero, content |
+| Page | `page` | hero, content, sidebar |
+
+**Blog Post fields:** excerpt, author, tags, published_date, featured_image
+
+## Block types
+
+| Block Type | Slug | Description |
+|-----------|------|-------------|
+| Rich Text | `rich_text` | TipTap rich text content |
+| Hero | `hero` | Banner with heading, subheading, and background image |
+| Image | `image` | Single image with alt text and caption |
+| CTA Button | `cta_button` | Call-to-action button with configurable style |

--- a/templates/blog/seed.json
+++ b/templates/blog/seed.json
@@ -1,0 +1,426 @@
+{
+  "version": 1,
+  "blockTypes": [
+    {
+      "id": 1,
+      "name": "Rich Text",
+      "slug": "rich_text",
+      "description": "A rich text content block using TipTap JSON format",
+      "fieldsSchema": [
+        { "name": "body", "label": "Body", "type": "richtext", "required": true }
+      ],
+      "icon": "text",
+      "settings": {},
+      "createdAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 2,
+      "name": "Hero",
+      "slug": "hero",
+      "description": "A hero banner with heading, subheading, and optional background image",
+      "fieldsSchema": [
+        { "name": "heading", "label": "Heading", "type": "text", "required": true },
+        { "name": "subheading", "label": "Subheading", "type": "text" },
+        { "name": "background_image", "label": "Background Image", "type": "media" }
+      ],
+      "icon": "layout",
+      "settings": {},
+      "createdAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 3,
+      "name": "Image",
+      "slug": "image",
+      "description": "A single image with optional caption and alt text",
+      "fieldsSchema": [
+        { "name": "src", "label": "Image", "type": "media", "required": true },
+        { "name": "alt", "label": "Alt Text", "type": "text", "required": true },
+        { "name": "caption", "label": "Caption", "type": "text" }
+      ],
+      "icon": "image",
+      "settings": {},
+      "createdAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 4,
+      "name": "CTA Button",
+      "slug": "cta_button",
+      "description": "A call-to-action button with configurable text, URL, and style",
+      "fieldsSchema": [
+        { "name": "text", "label": "Button Text", "type": "text", "required": true },
+        { "name": "url", "label": "URL", "type": "url", "required": true },
+        { "name": "style", "label": "Style", "type": "select", "options": ["primary", "secondary", "outline"] }
+      ],
+      "icon": "mouse-pointer",
+      "settings": {},
+      "createdAt": "2026-01-01T00:00:00.000Z"
+    }
+  ],
+  "contentTypes": [
+    {
+      "id": 1,
+      "name": "Blog Post",
+      "slug": "blog_post",
+      "description": "A blog post with hero area and main content",
+      "fieldsSchema": [
+        { "name": "excerpt", "label": "Excerpt", "type": "text" },
+        { "name": "author", "label": "Author", "type": "text" },
+        { "name": "tags", "label": "Tags", "type": "text" },
+        { "name": "published_date", "label": "Published Date", "type": "date" },
+        { "name": "featured_image", "label": "Featured Image", "type": "media" }
+      ],
+      "regions": [
+        { "name": "hero", "label": "Hero" },
+        { "name": "content", "label": "Content" }
+      ],
+      "defaultBlocks": [
+        { "region": "hero", "blockTypeSlug": "hero", "position": 0 },
+        { "region": "content", "blockTypeSlug": "rich_text", "position": 0 }
+      ],
+      "settings": {}
+    },
+    {
+      "id": 2,
+      "name": "Page",
+      "slug": "page",
+      "description": "A general-purpose page with hero, content, and sidebar regions",
+      "fieldsSchema": [],
+      "regions": [
+        { "name": "hero", "label": "Hero" },
+        { "name": "content", "label": "Content" },
+        { "name": "sidebar", "label": "Sidebar" }
+      ],
+      "defaultBlocks": [
+        { "region": "hero", "blockTypeSlug": "hero", "position": 0 },
+        { "region": "content", "blockTypeSlug": "rich_text", "position": 0 }
+      ],
+      "settings": {}
+    }
+  ],
+  "taxonomies": [
+    {
+      "id": 1,
+      "name": "Tags",
+      "slug": "tags",
+      "description": "Blog post tags for categorization",
+      "hierarchical": false
+    }
+  ],
+  "terms": [
+    { "id": 1, "taxonomyId": 1, "name": "Technology", "slug": "technology", "weight": 0 },
+    { "id": 2, "taxonomyId": 1, "name": "Tutorial", "slug": "tutorial", "weight": 1 },
+    { "id": 3, "taxonomyId": 1, "name": "News", "slug": "news", "weight": 2 },
+    { "id": 4, "taxonomyId": 1, "name": "Opinion", "slug": "opinion", "weight": 3 }
+  ],
+  "pages": [
+    {
+      "id": 1,
+      "typeId": 2,
+      "title": "Home",
+      "slug": "home",
+      "status": "published",
+      "locale": "en",
+      "fields": {},
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z",
+      "publishedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 2,
+      "typeId": 2,
+      "title": "About",
+      "slug": "about",
+      "status": "published",
+      "locale": "en",
+      "fields": {},
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z",
+      "publishedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 3,
+      "typeId": 1,
+      "title": "Getting Started with WollyCMS",
+      "slug": "getting-started-with-wollycms",
+      "status": "published",
+      "locale": "en",
+      "fields": {
+        "excerpt": "A beginner's guide to setting up and using WollyCMS for your blog.",
+        "author": "Admin",
+        "tags": "technology, tutorial",
+        "published_date": "2026-01-01",
+        "featured_image": ""
+      },
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z",
+      "publishedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 4,
+      "typeId": 1,
+      "title": "Why Headless CMS Is the Future",
+      "slug": "why-headless-cms-is-the-future",
+      "status": "published",
+      "locale": "en",
+      "fields": {
+        "excerpt": "Exploring the benefits of headless CMS architecture for modern websites.",
+        "author": "Admin",
+        "tags": "technology, opinion",
+        "published_date": "2026-01-05",
+        "featured_image": ""
+      },
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z",
+      "publishedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 5,
+      "typeId": 1,
+      "title": "Building Custom Block Types",
+      "slug": "building-custom-block-types",
+      "status": "published",
+      "locale": "en",
+      "fields": {
+        "excerpt": "Learn how to create custom block types to extend your WollyCMS site.",
+        "author": "Admin",
+        "tags": "tutorial",
+        "published_date": "2026-01-10",
+        "featured_image": ""
+      },
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z",
+      "publishedAt": "2026-01-01T00:00:00.000Z"
+    }
+  ],
+  "blocks": [
+    {
+      "id": 1,
+      "typeId": 2,
+      "title": "Home Hero",
+      "fields": {
+        "heading": "Welcome to Our Blog",
+        "subheading": "Thoughts, tutorials, and stories from our team",
+        "background_image": ""
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 2,
+      "typeId": 1,
+      "title": "Home Intro",
+      "fields": {
+        "body": {
+          "type": "doc",
+          "content": [
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "Welcome to our blog. Here you will find the latest posts on technology, tutorials, news, and opinion pieces from our team." }]
+            },
+            {
+              "type": "heading",
+              "attrs": { "level": 2 },
+              "content": [{ "type": "text", "text": "Recent Posts" }]
+            },
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "Check out the latest articles below, or browse by tag to find topics that interest you." }]
+            }
+          ]
+        }
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 3,
+      "typeId": 2,
+      "title": "About Hero",
+      "fields": {
+        "heading": "About Us",
+        "subheading": "Learn more about who we are and what we do",
+        "background_image": ""
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 4,
+      "typeId": 1,
+      "title": "About Content",
+      "fields": {
+        "body": {
+          "type": "doc",
+          "content": [
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "We are a team of writers and developers passionate about technology and the open web. This blog is powered by WollyCMS, a headless content management system designed for modern Astro frontends." }]
+            },
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "Our mission is to share knowledge, document our journey, and help others build better websites." }]
+            }
+          ]
+        }
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 5,
+      "typeId": 2,
+      "title": "Post 1 Hero",
+      "fields": {
+        "heading": "Getting Started with WollyCMS",
+        "subheading": "A beginner's guide to your new CMS",
+        "background_image": ""
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 6,
+      "typeId": 1,
+      "title": "Post 1 Content",
+      "fields": {
+        "body": {
+          "type": "doc",
+          "content": [
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "WollyCMS is a headless content management system built with Hono and designed to pair with Astro frontends. In this post, we will walk through the basics of getting your site set up." }]
+            },
+            {
+              "type": "heading",
+              "attrs": { "level": 2 },
+              "content": [{ "type": "text", "text": "Installation" }]
+            },
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "Start by creating a new project with the WollyCMS CLI. Run the create command, choose your template, and you are ready to go in minutes." }]
+            },
+            {
+              "type": "heading",
+              "attrs": { "level": 2 },
+              "content": [{ "type": "text", "text": "Creating Content" }]
+            },
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "The admin interface lets you create pages using composable blocks. Add a hero, drop in some rich text, and publish. Your Astro frontend fetches the content at build time or on request." }]
+            }
+          ]
+        }
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 7,
+      "typeId": 2,
+      "title": "Post 2 Hero",
+      "fields": {
+        "heading": "Why Headless CMS Is the Future",
+        "subheading": "Decoupled architecture for the modern web",
+        "background_image": ""
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 8,
+      "typeId": 1,
+      "title": "Post 2 Content",
+      "fields": {
+        "body": {
+          "type": "doc",
+          "content": [
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "Traditional CMSs tightly couple the content management layer with the presentation layer. Headless CMS breaks this apart, giving developers freedom to choose any frontend technology." }]
+            },
+            {
+              "type": "heading",
+              "attrs": { "level": 2 },
+              "content": [{ "type": "text", "text": "Benefits of Going Headless" }]
+            },
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "Performance, security, and developer experience all improve when your CMS is an API. Your frontend can be statically generated, server-rendered, or a mix of both." }]
+            }
+          ]
+        }
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 9,
+      "typeId": 2,
+      "title": "Post 3 Hero",
+      "fields": {
+        "heading": "Building Custom Block Types",
+        "subheading": "Extend WollyCMS with your own blocks",
+        "background_image": ""
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 10,
+      "typeId": 1,
+      "title": "Post 3 Content",
+      "fields": {
+        "body": {
+          "type": "doc",
+          "content": [
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "One of the most powerful features of WollyCMS is its extensible block system. You can define custom block types with their own field schemas, then render them however you like in your Astro frontend." }]
+            },
+            {
+              "type": "heading",
+              "attrs": { "level": 2 },
+              "content": [{ "type": "text", "text": "Defining a Block Type" }]
+            },
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "Block types are defined with a name, slug, and a fields schema. The schema tells the admin UI what form fields to render, and your frontend what data to expect." }]
+            }
+          ]
+        }
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    }
+  ],
+  "pageBlocks": [
+    { "id": 1, "pageId": 1, "blockId": 1, "region": "hero", "position": 0, "isShared": false },
+    { "id": 2, "pageId": 1, "blockId": 2, "region": "content", "position": 0, "isShared": false },
+    { "id": 3, "pageId": 2, "blockId": 3, "region": "hero", "position": 0, "isShared": false },
+    { "id": 4, "pageId": 2, "blockId": 4, "region": "content", "position": 0, "isShared": false },
+    { "id": 5, "pageId": 3, "blockId": 5, "region": "hero", "position": 0, "isShared": false },
+    { "id": 6, "pageId": 3, "blockId": 6, "region": "content", "position": 0, "isShared": false },
+    { "id": 7, "pageId": 4, "blockId": 7, "region": "hero", "position": 0, "isShared": false },
+    { "id": 8, "pageId": 4, "blockId": 8, "region": "content", "position": 0, "isShared": false },
+    { "id": 9, "pageId": 5, "blockId": 9, "region": "hero", "position": 0, "isShared": false },
+    { "id": 10, "pageId": 5, "blockId": 10, "region": "content", "position": 0, "isShared": false }
+  ],
+  "menus": [
+    { "id": 1, "name": "Main Navigation", "slug": "main-nav" }
+  ],
+  "menuItems": [
+    { "id": 1, "menuId": 1, "title": "Home", "url": "/", "pageId": 1, "target": "_self", "position": 0, "depth": 0, "parentId": null, "isExpanded": false, "attributes": {} },
+    { "id": 2, "menuId": 1, "title": "Blog", "url": "/blog", "pageId": null, "target": "_self", "position": 1, "depth": 0, "parentId": null, "isExpanded": false, "attributes": {} },
+    { "id": 3, "menuId": 1, "title": "About", "url": "/about", "pageId": 2, "target": "_self", "position": 2, "depth": 0, "parentId": null, "isExpanded": false, "attributes": {} }
+  ]
+}

--- a/templates/college/README.md
+++ b/templates/college/README.md
@@ -1,0 +1,53 @@
+# WollyCMS College Template
+
+A higher education site template with academic programs, news articles, events, department taxonomies, and campus information pages.
+
+## What's included
+
+- 6 content types, 10 block types, 12 sample pages
+- Pre-configured taxonomies (Departments: Business, Sciences, Arts & Humanities, Health Sciences, Technology; Tags: admissions, financial-aid, student-life, athletics)
+- Main navigation (About, Admissions, Academics, Student Life, Contact) and Footer navigation (Campus Map, Privacy, Accessibility)
+- 2 sample academic programs, 2 news articles, 1 campus event
+- Admissions page with FAQ accordion and apply CTA
+- Contact page with departmental contact list
+- Ready to customize
+
+## Quick start
+
+```bash
+npx create-wolly my-site --template college
+cd my-site
+wolly migrate
+wolly import templates/college/seed.json
+wolly start
+```
+
+## Content types
+
+| Content Type | Slug | Regions |
+|-------------|------|---------|
+| Home Page | `home_page` | hero, content, features, bottom |
+| Landing Page | `landing_page` | hero, content, features, bottom |
+| Secondary Page | `secondary_page` | hero, content, sidebar, bottom |
+| Program | `program` | hero, content, sidebar |
+| Article | `article` | hero, content, sidebar |
+| Event | `event` | hero, content, sidebar |
+
+**Program fields:** department, degree_type (associate/bachelor/certificate), credits, application_url
+**Event fields:** event_date, event_time, location, registration_url
+**Article fields:** body_summary, author, tags, published_date
+
+## Block types
+
+| Block Type | Slug | Description |
+|-----------|------|-------------|
+| Rich Text | `rich_text` | TipTap rich text content |
+| Hero | `hero` | Banner with heading, subheading, and background image |
+| Image | `image` | Single image with alt text and caption |
+| CTA Button | `cta_button` | Call-to-action button with configurable style |
+| Accordion | `accordion` | Expandable FAQ or collapsible content sections |
+| Contact List | `contact_list` | List of contacts with name, title, email, phone |
+| Location | `location` | Address, coordinates, and optional map embed |
+| Content Listing | `content_listing` | Dynamic content listing filtered by type and taxonomy |
+| Link List | `link_list` | Styled list of links with optional descriptions |
+| Embed | `embed` | Embed external content via URL or HTML |

--- a/templates/college/seed.json
+++ b/templates/college/seed.json
@@ -1,0 +1,1057 @@
+{
+  "version": 1,
+  "blockTypes": [
+    {
+      "id": 1,
+      "name": "Rich Text",
+      "slug": "rich_text",
+      "description": "A rich text content block using TipTap JSON format",
+      "fieldsSchema": [
+        { "name": "body", "label": "Body", "type": "richtext", "required": true }
+      ],
+      "icon": "text",
+      "settings": {},
+      "createdAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 2,
+      "name": "Hero",
+      "slug": "hero",
+      "description": "A hero banner with heading, subheading, and optional background image",
+      "fieldsSchema": [
+        { "name": "heading", "label": "Heading", "type": "text", "required": true },
+        { "name": "subheading", "label": "Subheading", "type": "text" },
+        { "name": "background_image", "label": "Background Image", "type": "media" }
+      ],
+      "icon": "layout",
+      "settings": {},
+      "createdAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 3,
+      "name": "Image",
+      "slug": "image",
+      "description": "A single image with optional caption and alt text",
+      "fieldsSchema": [
+        { "name": "src", "label": "Image", "type": "media", "required": true },
+        { "name": "alt", "label": "Alt Text", "type": "text", "required": true },
+        { "name": "caption", "label": "Caption", "type": "text" }
+      ],
+      "icon": "image",
+      "settings": {},
+      "createdAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 4,
+      "name": "CTA Button",
+      "slug": "cta_button",
+      "description": "A call-to-action button with configurable text, URL, and style",
+      "fieldsSchema": [
+        { "name": "text", "label": "Button Text", "type": "text", "required": true },
+        { "name": "url", "label": "URL", "type": "url", "required": true },
+        { "name": "style", "label": "Style", "type": "select", "options": ["primary", "secondary", "outline"] }
+      ],
+      "icon": "mouse-pointer",
+      "settings": {},
+      "createdAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 5,
+      "name": "Accordion",
+      "slug": "accordion",
+      "description": "Expandable accordion sections for FAQs or collapsible content",
+      "fieldsSchema": [
+        {
+          "name": "items",
+          "label": "Accordion Items",
+          "type": "repeater",
+          "fields": [
+            { "name": "title", "label": "Title", "type": "text" },
+            { "name": "content", "label": "Content", "type": "textarea" }
+          ]
+        }
+      ],
+      "icon": "chevrons-down",
+      "settings": {},
+      "createdAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 6,
+      "name": "Contact List",
+      "slug": "contact_list",
+      "description": "A list of contacts with name, title, email, and phone",
+      "fieldsSchema": [
+        {
+          "name": "contacts",
+          "label": "Contacts",
+          "type": "repeater",
+          "fields": [
+            { "name": "name", "label": "Name", "type": "text" },
+            { "name": "title", "label": "Title", "type": "text" },
+            { "name": "email", "label": "Email", "type": "text" },
+            { "name": "phone", "label": "Phone", "type": "text" }
+          ]
+        }
+      ],
+      "icon": "users",
+      "settings": {},
+      "createdAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 7,
+      "name": "Location",
+      "slug": "location",
+      "description": "A location block with address, coordinates, and optional map embed",
+      "fieldsSchema": [
+        { "name": "name", "label": "Location Name", "type": "text" },
+        { "name": "address", "label": "Address", "type": "textarea" },
+        { "name": "latitude", "label": "Latitude", "type": "text" },
+        { "name": "longitude", "label": "Longitude", "type": "text" },
+        { "name": "map_embed", "label": "Map Embed URL", "type": "url" }
+      ],
+      "icon": "map-pin",
+      "settings": {},
+      "createdAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 8,
+      "name": "Content Listing",
+      "slug": "content_listing",
+      "description": "A dynamic listing of content filtered by type, taxonomy, or custom query",
+      "fieldsSchema": [
+        { "name": "content_type", "label": "Content Type Slug", "type": "text" },
+        { "name": "limit", "label": "Number of Items", "type": "number" },
+        { "name": "taxonomy_filter", "label": "Taxonomy Filter (slug)", "type": "text" },
+        { "name": "display_style", "label": "Display Style", "type": "select", "options": ["list", "grid", "cards"] }
+      ],
+      "icon": "list",
+      "settings": {},
+      "createdAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 9,
+      "name": "Link List",
+      "slug": "link_list",
+      "description": "A styled list of links with optional descriptions",
+      "fieldsSchema": [
+        { "name": "heading", "label": "Heading", "type": "text" },
+        {
+          "name": "links",
+          "label": "Links",
+          "type": "repeater",
+          "fields": [
+            { "name": "text", "label": "Link Text", "type": "text" },
+            { "name": "url", "label": "URL", "type": "url" },
+            { "name": "description", "label": "Description", "type": "text" }
+          ]
+        }
+      ],
+      "icon": "link",
+      "settings": {},
+      "createdAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 10,
+      "name": "Embed",
+      "slug": "embed",
+      "description": "Embed external content via URL or HTML snippet",
+      "fieldsSchema": [
+        { "name": "embed_url", "label": "Embed URL", "type": "url" },
+        { "name": "embed_html", "label": "Embed HTML", "type": "textarea" },
+        { "name": "caption", "label": "Caption", "type": "text" }
+      ],
+      "icon": "code",
+      "settings": {},
+      "createdAt": "2026-01-01T00:00:00.000Z"
+    }
+  ],
+  "contentTypes": [
+    {
+      "id": 1,
+      "name": "Home Page",
+      "slug": "home_page",
+      "description": "The main college homepage with hero, content, features, and bottom regions",
+      "fieldsSchema": [],
+      "regions": [
+        { "name": "hero", "label": "Hero" },
+        { "name": "content", "label": "Content" },
+        { "name": "features", "label": "Features" },
+        { "name": "bottom", "label": "Bottom" }
+      ],
+      "defaultBlocks": [
+        { "region": "hero", "blockTypeSlug": "hero", "position": 0 },
+        { "region": "content", "blockTypeSlug": "rich_text", "position": 0 }
+      ],
+      "settings": {}
+    },
+    {
+      "id": 2,
+      "name": "Landing Page",
+      "slug": "landing_page",
+      "description": "A full-width landing page for departments and campaigns",
+      "fieldsSchema": [],
+      "regions": [
+        { "name": "hero", "label": "Hero" },
+        { "name": "content", "label": "Content" },
+        { "name": "features", "label": "Features" },
+        { "name": "bottom", "label": "Bottom" }
+      ],
+      "defaultBlocks": [
+        { "region": "hero", "blockTypeSlug": "hero", "position": 0 },
+        { "region": "content", "blockTypeSlug": "rich_text", "position": 0 }
+      ],
+      "settings": {}
+    },
+    {
+      "id": 3,
+      "name": "Secondary Page",
+      "slug": "secondary_page",
+      "description": "A standard interior page with sidebar navigation",
+      "fieldsSchema": [],
+      "regions": [
+        { "name": "hero", "label": "Hero" },
+        { "name": "content", "label": "Content" },
+        { "name": "sidebar", "label": "Sidebar" },
+        { "name": "bottom", "label": "Bottom" }
+      ],
+      "defaultBlocks": [
+        { "region": "hero", "blockTypeSlug": "hero", "position": 0 },
+        { "region": "content", "blockTypeSlug": "rich_text", "position": 0 }
+      ],
+      "settings": {}
+    },
+    {
+      "id": 4,
+      "name": "Program",
+      "slug": "program",
+      "description": "An academic program or degree page with department, degree type, and credits",
+      "fieldsSchema": [
+        { "name": "department", "label": "Department", "type": "text" },
+        { "name": "degree_type", "label": "Degree Type", "type": "select", "options": ["associate", "bachelor", "certificate"] },
+        { "name": "credits", "label": "Credits", "type": "number" },
+        { "name": "application_url", "label": "Application URL", "type": "url" }
+      ],
+      "regions": [
+        { "name": "hero", "label": "Hero" },
+        { "name": "content", "label": "Content" },
+        { "name": "sidebar", "label": "Sidebar" }
+      ],
+      "defaultBlocks": [
+        { "region": "hero", "blockTypeSlug": "hero", "position": 0 },
+        { "region": "content", "blockTypeSlug": "rich_text", "position": 0 }
+      ],
+      "settings": {}
+    },
+    {
+      "id": 5,
+      "name": "Article",
+      "slug": "article",
+      "description": "A news article or press release",
+      "fieldsSchema": [
+        { "name": "body_summary", "label": "Summary", "type": "textarea" },
+        { "name": "author", "label": "Author", "type": "text" },
+        { "name": "tags", "label": "Tags", "type": "text" },
+        { "name": "published_date", "label": "Published Date", "type": "date" }
+      ],
+      "regions": [
+        { "name": "hero", "label": "Hero" },
+        { "name": "content", "label": "Content" },
+        { "name": "sidebar", "label": "Sidebar" }
+      ],
+      "defaultBlocks": [
+        { "region": "hero", "blockTypeSlug": "hero", "position": 0 },
+        { "region": "content", "blockTypeSlug": "rich_text", "position": 0 }
+      ],
+      "settings": {}
+    },
+    {
+      "id": 6,
+      "name": "Event",
+      "slug": "event",
+      "description": "A campus event with date, time, location, and registration",
+      "fieldsSchema": [
+        { "name": "event_date", "label": "Event Date", "type": "text" },
+        { "name": "event_time", "label": "Event Time", "type": "text" },
+        { "name": "location", "label": "Location", "type": "text" },
+        { "name": "registration_url", "label": "Registration URL", "type": "url" }
+      ],
+      "regions": [
+        { "name": "hero", "label": "Hero" },
+        { "name": "content", "label": "Content" },
+        { "name": "sidebar", "label": "Sidebar" }
+      ],
+      "defaultBlocks": [
+        { "region": "hero", "blockTypeSlug": "hero", "position": 0 },
+        { "region": "content", "blockTypeSlug": "rich_text", "position": 0 }
+      ],
+      "settings": {}
+    }
+  ],
+  "taxonomies": [
+    {
+      "id": 1,
+      "name": "Departments",
+      "slug": "departments",
+      "description": "Academic departments — hierarchical",
+      "hierarchical": true
+    },
+    {
+      "id": 2,
+      "name": "Tags",
+      "slug": "tags",
+      "description": "General content tags",
+      "hierarchical": false
+    }
+  ],
+  "terms": [
+    { "id": 1, "taxonomyId": 1, "name": "Business", "slug": "business", "weight": 0 },
+    { "id": 2, "taxonomyId": 1, "name": "Sciences", "slug": "sciences", "weight": 1 },
+    { "id": 3, "taxonomyId": 1, "name": "Arts & Humanities", "slug": "arts-humanities", "weight": 2 },
+    { "id": 4, "taxonomyId": 1, "name": "Health Sciences", "slug": "health-sciences", "weight": 3 },
+    { "id": 5, "taxonomyId": 1, "name": "Technology", "slug": "technology", "weight": 4 },
+    { "id": 6, "taxonomyId": 2, "name": "admissions", "slug": "admissions", "weight": 0 },
+    { "id": 7, "taxonomyId": 2, "name": "financial-aid", "slug": "financial-aid", "weight": 1 },
+    { "id": 8, "taxonomyId": 2, "name": "student-life", "slug": "student-life", "weight": 2 },
+    { "id": 9, "taxonomyId": 2, "name": "athletics", "slug": "athletics", "weight": 3 }
+  ],
+  "pages": [
+    {
+      "id": 1,
+      "typeId": 1,
+      "title": "Home",
+      "slug": "home",
+      "status": "published",
+      "locale": "en",
+      "fields": {},
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z",
+      "publishedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 2,
+      "typeId": 3,
+      "title": "About",
+      "slug": "about",
+      "status": "published",
+      "locale": "en",
+      "fields": {},
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z",
+      "publishedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 3,
+      "typeId": 2,
+      "title": "Admissions",
+      "slug": "admissions",
+      "status": "published",
+      "locale": "en",
+      "fields": {},
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z",
+      "publishedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 4,
+      "typeId": 2,
+      "title": "Academics",
+      "slug": "academics",
+      "status": "published",
+      "locale": "en",
+      "fields": {},
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z",
+      "publishedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 5,
+      "typeId": 3,
+      "title": "Student Life",
+      "slug": "student-life",
+      "status": "published",
+      "locale": "en",
+      "fields": {},
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z",
+      "publishedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 6,
+      "typeId": 3,
+      "title": "Campus Map",
+      "slug": "campus-map",
+      "status": "published",
+      "locale": "en",
+      "fields": {},
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z",
+      "publishedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 7,
+      "typeId": 3,
+      "title": "Contact",
+      "slug": "contact",
+      "status": "published",
+      "locale": "en",
+      "fields": {},
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z",
+      "publishedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 8,
+      "typeId": 4,
+      "title": "Business Administration",
+      "slug": "business-administration",
+      "status": "published",
+      "locale": "en",
+      "fields": {
+        "department": "Business",
+        "degree_type": "associate",
+        "credits": 60,
+        "application_url": "https://example.edu/apply"
+      },
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z",
+      "publishedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 9,
+      "typeId": 4,
+      "title": "Computer Science",
+      "slug": "computer-science",
+      "status": "published",
+      "locale": "en",
+      "fields": {
+        "department": "Technology",
+        "degree_type": "associate",
+        "credits": 64,
+        "application_url": "https://example.edu/apply"
+      },
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z",
+      "publishedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 10,
+      "typeId": 5,
+      "title": "Fall Enrollment Numbers Reach Record High",
+      "slug": "fall-enrollment-numbers-reach-record-high",
+      "status": "published",
+      "locale": "en",
+      "fields": {
+        "body_summary": "The college reports its highest enrollment numbers in over a decade as new programs attract students from across the region.",
+        "author": "Communications Office",
+        "tags": "admissions",
+        "published_date": "2026-01-15"
+      },
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z",
+      "publishedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 11,
+      "typeId": 5,
+      "title": "New Scholarship Program Announced",
+      "slug": "new-scholarship-program-announced",
+      "status": "published",
+      "locale": "en",
+      "fields": {
+        "body_summary": "A generous donation from alumni establishes a new scholarship fund for students in health sciences and technology programs.",
+        "author": "Communications Office",
+        "tags": "financial-aid",
+        "published_date": "2026-01-20"
+      },
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z",
+      "publishedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 12,
+      "typeId": 6,
+      "title": "Spring Open House",
+      "slug": "spring-open-house",
+      "status": "published",
+      "locale": "en",
+      "fields": {
+        "event_date": "2026-04-10",
+        "event_time": "9:00 AM - 3:00 PM",
+        "location": "Main Campus",
+        "registration_url": "https://example.edu/open-house"
+      },
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z",
+      "publishedAt": "2026-01-01T00:00:00.000Z"
+    }
+  ],
+  "blocks": [
+    {
+      "id": 1,
+      "typeId": 2,
+      "title": "Home Hero",
+      "fields": {
+        "heading": "Your Future Starts Here",
+        "subheading": "Discover programs designed to launch your career and transform your life",
+        "background_image": ""
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 2,
+      "typeId": 9,
+      "title": "Home Features",
+      "fields": {
+        "heading": "Quick Links",
+        "links": [
+          { "text": "Apply Now", "url": "/admissions", "description": "Start your application today" },
+          { "text": "Programs", "url": "/academics", "description": "Explore our degree programs" },
+          { "text": "Financial Aid", "url": "/admissions#financial-aid", "description": "Scholarships and aid information" },
+          { "text": "Campus Visit", "url": "/admissions#visit", "description": "Schedule a campus tour" }
+        ]
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 3,
+      "typeId": 8,
+      "title": "Home News Listing",
+      "fields": {
+        "content_type": "article",
+        "limit": 3,
+        "taxonomy_filter": "",
+        "display_style": "cards"
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 4,
+      "typeId": 2,
+      "title": "About Hero",
+      "fields": {
+        "heading": "About Our College",
+        "subheading": "A tradition of excellence in education since 1965",
+        "background_image": ""
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 5,
+      "typeId": 1,
+      "title": "About Content",
+      "fields": {
+        "body": {
+          "type": "doc",
+          "content": [
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "Our college has been serving the community for over 60 years, providing affordable, high-quality education that prepares students for successful careers and lifelong learning." }]
+            },
+            {
+              "type": "heading",
+              "attrs": { "level": 2 },
+              "content": [{ "type": "text", "text": "Mission" }]
+            },
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "We are committed to student success through innovative teaching, comprehensive support services, and strong community partnerships." }]
+            }
+          ]
+        }
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 6,
+      "typeId": 5,
+      "title": "About FAQ",
+      "fields": {
+        "items": [
+          { "title": "What types of degrees do you offer?", "content": "We offer associate degrees, bachelor degrees, and certificate programs across five academic departments." },
+          { "title": "What is the student-to-faculty ratio?", "content": "Our average class size is 22 students, with a student-to-faculty ratio of 18:1." },
+          { "title": "Do you offer online courses?", "content": "Yes. Many of our programs are available fully online or in a hybrid format combining online and in-person instruction." },
+          { "title": "How do I schedule a campus visit?", "content": "Visit our Admissions page to schedule a campus tour. We offer both individual and group tours throughout the academic year." }
+        ]
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 7,
+      "typeId": 2,
+      "title": "Admissions Hero",
+      "fields": {
+        "heading": "Admissions",
+        "subheading": "Take the first step toward your future",
+        "background_image": ""
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 8,
+      "typeId": 1,
+      "title": "Admissions Content",
+      "fields": {
+        "body": {
+          "type": "doc",
+          "content": [
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "Applying is simple. Whether you are a first-time college student, transferring from another institution, or returning to finish your degree, we are here to help you through every step of the process." }]
+            },
+            {
+              "type": "heading",
+              "attrs": { "level": 2 },
+              "content": [{ "type": "text", "text": "How to Apply" }]
+            },
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "Complete our online application — it takes about 15 minutes. There is no application fee." }]
+            }
+          ]
+        }
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 9,
+      "typeId": 4,
+      "title": "Admissions CTA",
+      "fields": {
+        "text": "Apply Now",
+        "url": "https://example.edu/apply",
+        "style": "primary"
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 10,
+      "typeId": 5,
+      "title": "Admissions FAQ",
+      "fields": {
+        "items": [
+          { "title": "What are the admission requirements?", "content": "Requirements vary by program. Most programs require a high school diploma or GED. Some programs have additional prerequisites." },
+          { "title": "When are the application deadlines?", "content": "We accept applications on a rolling basis. Priority deadlines are March 1 for fall and October 1 for spring." },
+          { "title": "Is financial aid available?", "content": "Yes. We offer federal financial aid, state grants, institutional scholarships, and work-study programs. Complete the FAFSA to get started." },
+          { "title": "Can I transfer credits from another college?", "content": "We accept transfer credits from accredited institutions. Contact the Registrar for a transfer credit evaluation." }
+        ]
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 11,
+      "typeId": 2,
+      "title": "Academics Hero",
+      "fields": {
+        "heading": "Academics",
+        "subheading": "Explore our programs and find the right fit for your goals",
+        "background_image": ""
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 12,
+      "typeId": 8,
+      "title": "Academics Program Listing",
+      "fields": {
+        "content_type": "program",
+        "limit": 20,
+        "taxonomy_filter": "",
+        "display_style": "grid"
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 13,
+      "typeId": 2,
+      "title": "Student Life Hero",
+      "fields": {
+        "heading": "Student Life",
+        "subheading": "More than a degree — a complete college experience",
+        "background_image": ""
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 14,
+      "typeId": 1,
+      "title": "Student Life Content",
+      "fields": {
+        "body": {
+          "type": "doc",
+          "content": [
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "College is about more than classes. Get involved in student organizations, intramural sports, community service, and campus events. Our Student Life office is here to help you make the most of your time with us." }]
+            },
+            {
+              "type": "heading",
+              "attrs": { "level": 2 },
+              "content": [{ "type": "text", "text": "Student Organizations" }]
+            },
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "We have over 30 student clubs and organizations covering everything from academic honor societies to recreational sports and cultural groups." }]
+            },
+            {
+              "type": "heading",
+              "attrs": { "level": 2 },
+              "content": [{ "type": "text", "text": "Support Services" }]
+            },
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "Tutoring, counseling, career services, and disability accommodations are available to all enrolled students at no extra cost." }]
+            }
+          ]
+        }
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 15,
+      "typeId": 2,
+      "title": "Campus Map Hero",
+      "fields": {
+        "heading": "Campus Map",
+        "subheading": "Find your way around campus",
+        "background_image": ""
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 16,
+      "typeId": 7,
+      "title": "Campus Location",
+      "fields": {
+        "name": "Main Campus",
+        "address": "1000 College Drive\nAnytown, ST 12345",
+        "latitude": "40.7128",
+        "longitude": "-74.0060",
+        "map_embed": ""
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 17,
+      "typeId": 2,
+      "title": "Contact Hero",
+      "fields": {
+        "heading": "Contact Us",
+        "subheading": "We are here to help",
+        "background_image": ""
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 18,
+      "typeId": 6,
+      "title": "Contact List",
+      "fields": {
+        "contacts": [
+          { "name": "Admissions Office", "title": "New Student Enrollment", "email": "admissions@example.edu", "phone": "(555) 100-2000" },
+          { "name": "Financial Aid Office", "title": "Scholarships & Aid", "email": "finaid@example.edu", "phone": "(555) 100-2001" },
+          { "name": "Registrar", "title": "Records & Transcripts", "email": "registrar@example.edu", "phone": "(555) 100-2002" },
+          { "name": "Student Services", "title": "General Support", "email": "studentservices@example.edu", "phone": "(555) 100-2003" }
+        ]
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 19,
+      "typeId": 2,
+      "title": "Program 1 Hero",
+      "fields": {
+        "heading": "Business Administration",
+        "subheading": "Associate Degree — 60 Credits",
+        "background_image": ""
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 20,
+      "typeId": 1,
+      "title": "Program 1 Content",
+      "fields": {
+        "body": {
+          "type": "doc",
+          "content": [
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "The Business Administration program prepares students for careers in management, marketing, finance, and entrepreneurship. Graduates are ready to enter the workforce or transfer to a four-year institution." }]
+            },
+            {
+              "type": "heading",
+              "attrs": { "level": 2 },
+              "content": [{ "type": "text", "text": "Program Highlights" }]
+            },
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "Small class sizes, experienced faculty with industry backgrounds, internship opportunities with local businesses, and articulation agreements with regional universities." }]
+            }
+          ]
+        }
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 21,
+      "typeId": 4,
+      "title": "Program 1 CTA",
+      "fields": {
+        "text": "Apply to This Program",
+        "url": "https://example.edu/apply",
+        "style": "primary"
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 22,
+      "typeId": 2,
+      "title": "Program 2 Hero",
+      "fields": {
+        "heading": "Computer Science",
+        "subheading": "Associate Degree — 64 Credits",
+        "background_image": ""
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 23,
+      "typeId": 1,
+      "title": "Program 2 Content",
+      "fields": {
+        "body": {
+          "type": "doc",
+          "content": [
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "The Computer Science program provides a strong foundation in programming, data structures, algorithms, and software development. Students gain hands-on experience with modern technologies and development tools." }]
+            },
+            {
+              "type": "heading",
+              "attrs": { "level": 2 },
+              "content": [{ "type": "text", "text": "Career Paths" }]
+            },
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "Graduates pursue careers in software development, web development, database administration, systems analysis, and IT support. Many also transfer to four-year programs in computer science or information technology." }]
+            }
+          ]
+        }
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 24,
+      "typeId": 4,
+      "title": "Program 2 CTA",
+      "fields": {
+        "text": "Apply to This Program",
+        "url": "https://example.edu/apply",
+        "style": "primary"
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 25,
+      "typeId": 2,
+      "title": "Article 1 Hero",
+      "fields": {
+        "heading": "Fall Enrollment Numbers Reach Record High",
+        "subheading": "College reports highest enrollment in over a decade",
+        "background_image": ""
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 26,
+      "typeId": 1,
+      "title": "Article 1 Content",
+      "fields": {
+        "body": {
+          "type": "doc",
+          "content": [
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "The college is pleased to announce that fall enrollment has reached its highest level in over a decade. The increase is attributed to new academic programs, expanded online offerings, and enhanced student support services." }]
+            },
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "Programs in health sciences and technology saw the largest growth, with enrollment in those departments increasing by 25% compared to the previous year." }]
+            }
+          ]
+        }
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 27,
+      "typeId": 2,
+      "title": "Article 2 Hero",
+      "fields": {
+        "heading": "New Scholarship Program Announced",
+        "subheading": "Alumni donation creates new opportunities for students",
+        "background_image": ""
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 28,
+      "typeId": 1,
+      "title": "Article 2 Content",
+      "fields": {
+        "body": {
+          "type": "doc",
+          "content": [
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "A generous donation from the college alumni association has established a new scholarship fund targeting students in health sciences and technology programs." }]
+            },
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "The scholarship covers up to full tuition for qualifying students and is renewable for up to two years. Applications open on March 1." }]
+            }
+          ]
+        }
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 29,
+      "typeId": 2,
+      "title": "Event 1 Hero",
+      "fields": {
+        "heading": "Spring Open House",
+        "subheading": "Tour the campus and meet faculty and staff",
+        "background_image": ""
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 30,
+      "typeId": 1,
+      "title": "Event 1 Content",
+      "fields": {
+        "body": {
+          "type": "doc",
+          "content": [
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "Join us for our annual Spring Open House. Tour the campus, meet faculty and current students, learn about academic programs, and get information on admissions and financial aid." }]
+            },
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "The event is free and open to prospective students and their families. Register online to reserve your spot." }]
+            }
+          ]
+        }
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    }
+  ],
+  "pageBlocks": [
+    { "id": 1, "pageId": 1, "blockId": 1, "region": "hero", "position": 0, "isShared": false },
+    { "id": 2, "pageId": 1, "blockId": 2, "region": "features", "position": 0, "isShared": false },
+    { "id": 3, "pageId": 1, "blockId": 3, "region": "content", "position": 0, "isShared": false },
+    { "id": 4, "pageId": 2, "blockId": 4, "region": "hero", "position": 0, "isShared": false },
+    { "id": 5, "pageId": 2, "blockId": 5, "region": "content", "position": 0, "isShared": false },
+    { "id": 6, "pageId": 2, "blockId": 6, "region": "bottom", "position": 0, "isShared": false },
+    { "id": 7, "pageId": 3, "blockId": 7, "region": "hero", "position": 0, "isShared": false },
+    { "id": 8, "pageId": 3, "blockId": 8, "region": "content", "position": 0, "isShared": false },
+    { "id": 9, "pageId": 3, "blockId": 9, "region": "bottom", "position": 0, "isShared": false },
+    { "id": 10, "pageId": 3, "blockId": 10, "region": "features", "position": 0, "isShared": false },
+    { "id": 11, "pageId": 4, "blockId": 11, "region": "hero", "position": 0, "isShared": false },
+    { "id": 12, "pageId": 4, "blockId": 12, "region": "content", "position": 0, "isShared": false },
+    { "id": 13, "pageId": 5, "blockId": 13, "region": "hero", "position": 0, "isShared": false },
+    { "id": 14, "pageId": 5, "blockId": 14, "region": "content", "position": 0, "isShared": false },
+    { "id": 15, "pageId": 6, "blockId": 15, "region": "hero", "position": 0, "isShared": false },
+    { "id": 16, "pageId": 6, "blockId": 16, "region": "content", "position": 0, "isShared": false },
+    { "id": 17, "pageId": 7, "blockId": 17, "region": "hero", "position": 0, "isShared": false },
+    { "id": 18, "pageId": 7, "blockId": 18, "region": "content", "position": 0, "isShared": false },
+    { "id": 19, "pageId": 8, "blockId": 19, "region": "hero", "position": 0, "isShared": false },
+    { "id": 20, "pageId": 8, "blockId": 20, "region": "content", "position": 0, "isShared": false },
+    { "id": 21, "pageId": 8, "blockId": 21, "region": "sidebar", "position": 0, "isShared": false },
+    { "id": 22, "pageId": 9, "blockId": 22, "region": "hero", "position": 0, "isShared": false },
+    { "id": 23, "pageId": 9, "blockId": 23, "region": "content", "position": 0, "isShared": false },
+    { "id": 24, "pageId": 9, "blockId": 24, "region": "sidebar", "position": 0, "isShared": false },
+    { "id": 25, "pageId": 10, "blockId": 25, "region": "hero", "position": 0, "isShared": false },
+    { "id": 26, "pageId": 10, "blockId": 26, "region": "content", "position": 0, "isShared": false },
+    { "id": 27, "pageId": 11, "blockId": 27, "region": "hero", "position": 0, "isShared": false },
+    { "id": 28, "pageId": 11, "blockId": 28, "region": "content", "position": 0, "isShared": false },
+    { "id": 29, "pageId": 12, "blockId": 29, "region": "hero", "position": 0, "isShared": false },
+    { "id": 30, "pageId": 12, "blockId": 30, "region": "content", "position": 0, "isShared": false }
+  ],
+  "menus": [
+    { "id": 1, "name": "Main Navigation", "slug": "main-nav" },
+    { "id": 2, "name": "Footer Navigation", "slug": "footer-nav" }
+  ],
+  "menuItems": [
+    { "id": 1, "menuId": 1, "title": "About", "url": "/about", "pageId": 2, "target": "_self", "position": 0, "depth": 0, "parentId": null, "isExpanded": false, "attributes": {} },
+    { "id": 2, "menuId": 1, "title": "Admissions", "url": "/admissions", "pageId": 3, "target": "_self", "position": 1, "depth": 0, "parentId": null, "isExpanded": false, "attributes": {} },
+    { "id": 3, "menuId": 1, "title": "Academics", "url": "/academics", "pageId": 4, "target": "_self", "position": 2, "depth": 0, "parentId": null, "isExpanded": false, "attributes": {} },
+    { "id": 4, "menuId": 1, "title": "Student Life", "url": "/student-life", "pageId": 5, "target": "_self", "position": 3, "depth": 0, "parentId": null, "isExpanded": false, "attributes": {} },
+    { "id": 5, "menuId": 1, "title": "Contact", "url": "/contact", "pageId": 7, "target": "_self", "position": 4, "depth": 0, "parentId": null, "isExpanded": false, "attributes": {} },
+    { "id": 6, "menuId": 2, "title": "Campus Map", "url": "/campus-map", "pageId": 6, "target": "_self", "position": 0, "depth": 0, "parentId": null, "isExpanded": false, "attributes": {} },
+    { "id": 7, "menuId": 2, "title": "Privacy", "url": "/privacy", "pageId": null, "target": "_self", "position": 1, "depth": 0, "parentId": null, "isExpanded": false, "attributes": {} },
+    { "id": 8, "menuId": 2, "title": "Accessibility", "url": "/accessibility", "pageId": null, "target": "_self", "position": 2, "depth": 0, "parentId": null, "isExpanded": false, "attributes": {} }
+  ]
+}

--- a/templates/drupal/README.md
+++ b/templates/drupal/README.md
@@ -1,0 +1,59 @@
+# WollyCMS Drupal Template
+
+A familiar starting point for Drupal administrators migrating to WollyCMS, with content types, taxonomy vocabularies, and regions that map to Drupal concepts.
+
+## What's included
+
+- 4 content types, 8 block types, 10 sample pages
+- Pre-configured taxonomies (Tags: drupal, migration, cms, web-development; Content Category: News, Events, Resources)
+- Main navigation menu (Home, About, News, Events, Contact)
+- 3 sample articles, 2 sample events, contact page with contact list and location
+- Content listing blocks for news and events (similar to Drupal Views)
+- Ready to customize
+
+## Quick start
+
+```bash
+npx create-wolly my-site --template drupal
+cd my-site
+wolly migrate
+wolly import templates/drupal/seed.json
+wolly start
+```
+
+## Content types
+
+| Content Type | Slug | Regions |
+|-------------|------|---------|
+| Article | `article` | hero, content, sidebar |
+| Basic Page | `basic_page` | hero, content, sidebar, bottom |
+| Landing Page | `landing_page` | hero, content, features, bottom |
+| Event | `event` | hero, content, sidebar |
+
+**Article fields:** body_summary, author, tags, published_date
+**Event fields:** event_date, event_time, location, registration_url
+
+## Block types
+
+| Block Type | Slug | Description |
+|-----------|------|-------------|
+| Rich Text | `rich_text` | TipTap rich text content |
+| Hero | `hero` | Banner with heading, subheading, and background image |
+| Image | `image` | Single image with alt text and caption |
+| CTA Button | `cta_button` | Call-to-action button with configurable style |
+| Accordion | `accordion` | Expandable FAQ or collapsible content sections |
+| Contact List | `contact_list` | List of contacts with name, title, email, phone |
+| Location | `location` | Address, coordinates, and optional map embed |
+| Content Listing | `content_listing` | Dynamic content listing filtered by type and taxonomy |
+
+## Drupal concepts mapped to WollyCMS
+
+| Drupal | WollyCMS |
+|--------|----------|
+| Content Types | Content types with fieldsSchema |
+| Block Regions (theme) | Regions (per content type) |
+| Taxonomy Vocabularies | Taxonomies (flat or hierarchical) |
+| Views | Content listing blocks |
+| Custom Blocks | Reusable blocks (isReusable: true) |
+| Paragraphs / Layout Builder | Composable block regions |
+| Menus | Menus with nested menu items |

--- a/templates/drupal/seed.json
+++ b/templates/drupal/seed.json
@@ -1,0 +1,785 @@
+{
+  "version": 1,
+  "blockTypes": [
+    {
+      "id": 1,
+      "name": "Rich Text",
+      "slug": "rich_text",
+      "description": "A rich text content block using TipTap JSON format",
+      "fieldsSchema": [
+        { "name": "body", "label": "Body", "type": "richtext", "required": true }
+      ],
+      "icon": "text",
+      "settings": {},
+      "createdAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 2,
+      "name": "Hero",
+      "slug": "hero",
+      "description": "A hero banner with heading, subheading, and optional background image",
+      "fieldsSchema": [
+        { "name": "heading", "label": "Heading", "type": "text", "required": true },
+        { "name": "subheading", "label": "Subheading", "type": "text" },
+        { "name": "background_image", "label": "Background Image", "type": "media" }
+      ],
+      "icon": "layout",
+      "settings": {},
+      "createdAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 3,
+      "name": "Image",
+      "slug": "image",
+      "description": "A single image with optional caption and alt text",
+      "fieldsSchema": [
+        { "name": "src", "label": "Image", "type": "media", "required": true },
+        { "name": "alt", "label": "Alt Text", "type": "text", "required": true },
+        { "name": "caption", "label": "Caption", "type": "text" }
+      ],
+      "icon": "image",
+      "settings": {},
+      "createdAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 4,
+      "name": "CTA Button",
+      "slug": "cta_button",
+      "description": "A call-to-action button with configurable text, URL, and style",
+      "fieldsSchema": [
+        { "name": "text", "label": "Button Text", "type": "text", "required": true },
+        { "name": "url", "label": "URL", "type": "url", "required": true },
+        { "name": "style", "label": "Style", "type": "select", "options": ["primary", "secondary", "outline"] }
+      ],
+      "icon": "mouse-pointer",
+      "settings": {},
+      "createdAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 5,
+      "name": "Accordion",
+      "slug": "accordion",
+      "description": "Expandable accordion sections for FAQs or collapsible content",
+      "fieldsSchema": [
+        {
+          "name": "items",
+          "label": "Accordion Items",
+          "type": "repeater",
+          "fields": [
+            { "name": "title", "label": "Title", "type": "text" },
+            { "name": "content", "label": "Content", "type": "textarea" }
+          ]
+        }
+      ],
+      "icon": "chevrons-down",
+      "settings": {},
+      "createdAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 6,
+      "name": "Contact List",
+      "slug": "contact_list",
+      "description": "A list of contacts with name, title, email, and phone",
+      "fieldsSchema": [
+        {
+          "name": "contacts",
+          "label": "Contacts",
+          "type": "repeater",
+          "fields": [
+            { "name": "name", "label": "Name", "type": "text" },
+            { "name": "title", "label": "Title", "type": "text" },
+            { "name": "email", "label": "Email", "type": "text" },
+            { "name": "phone", "label": "Phone", "type": "text" }
+          ]
+        }
+      ],
+      "icon": "users",
+      "settings": {},
+      "createdAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 7,
+      "name": "Location",
+      "slug": "location",
+      "description": "A location block with address, coordinates, and optional map embed",
+      "fieldsSchema": [
+        { "name": "name", "label": "Location Name", "type": "text" },
+        { "name": "address", "label": "Address", "type": "textarea" },
+        { "name": "latitude", "label": "Latitude", "type": "text" },
+        { "name": "longitude", "label": "Longitude", "type": "text" },
+        { "name": "map_embed", "label": "Map Embed URL", "type": "url" }
+      ],
+      "icon": "map-pin",
+      "settings": {},
+      "createdAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 8,
+      "name": "Content Listing",
+      "slug": "content_listing",
+      "description": "A dynamic listing of content filtered by type, taxonomy, or custom query",
+      "fieldsSchema": [
+        { "name": "content_type", "label": "Content Type Slug", "type": "text" },
+        { "name": "limit", "label": "Number of Items", "type": "number" },
+        { "name": "taxonomy_filter", "label": "Taxonomy Filter (slug)", "type": "text" },
+        { "name": "display_style", "label": "Display Style", "type": "select", "options": ["list", "grid", "cards"] }
+      ],
+      "icon": "list",
+      "settings": {},
+      "createdAt": "2026-01-01T00:00:00.000Z"
+    }
+  ],
+  "contentTypes": [
+    {
+      "id": 1,
+      "name": "Article",
+      "slug": "article",
+      "description": "A news article or blog post — similar to Drupal's Article content type",
+      "fieldsSchema": [
+        { "name": "body_summary", "label": "Body Summary", "type": "textarea" },
+        { "name": "author", "label": "Author", "type": "text" },
+        { "name": "tags", "label": "Tags", "type": "text" },
+        { "name": "published_date", "label": "Published Date", "type": "date" }
+      ],
+      "regions": [
+        { "name": "hero", "label": "Hero" },
+        { "name": "content", "label": "Content" },
+        { "name": "sidebar", "label": "Sidebar" }
+      ],
+      "defaultBlocks": [
+        { "region": "hero", "blockTypeSlug": "hero", "position": 0 },
+        { "region": "content", "blockTypeSlug": "rich_text", "position": 0 }
+      ],
+      "settings": {}
+    },
+    {
+      "id": 2,
+      "name": "Basic Page",
+      "slug": "basic_page",
+      "description": "A general-purpose page — similar to Drupal's Basic Page content type",
+      "fieldsSchema": [],
+      "regions": [
+        { "name": "hero", "label": "Hero" },
+        { "name": "content", "label": "Content" },
+        { "name": "sidebar", "label": "Sidebar" },
+        { "name": "bottom", "label": "Bottom" }
+      ],
+      "defaultBlocks": [
+        { "region": "hero", "blockTypeSlug": "hero", "position": 0 },
+        { "region": "content", "blockTypeSlug": "rich_text", "position": 0 }
+      ],
+      "settings": {}
+    },
+    {
+      "id": 3,
+      "name": "Landing Page",
+      "slug": "landing_page",
+      "description": "A full-width landing page with hero, content, features, and bottom regions",
+      "fieldsSchema": [],
+      "regions": [
+        { "name": "hero", "label": "Hero" },
+        { "name": "content", "label": "Content" },
+        { "name": "features", "label": "Features" },
+        { "name": "bottom", "label": "Bottom" }
+      ],
+      "defaultBlocks": [
+        { "region": "hero", "blockTypeSlug": "hero", "position": 0 },
+        { "region": "content", "blockTypeSlug": "rich_text", "position": 0 }
+      ],
+      "settings": {}
+    },
+    {
+      "id": 4,
+      "name": "Event",
+      "slug": "event",
+      "description": "An event with date, time, location, and registration details",
+      "fieldsSchema": [
+        { "name": "event_date", "label": "Event Date", "type": "text" },
+        { "name": "event_time", "label": "Event Time", "type": "text" },
+        { "name": "location", "label": "Location", "type": "text" },
+        { "name": "registration_url", "label": "Registration URL", "type": "url" }
+      ],
+      "regions": [
+        { "name": "hero", "label": "Hero" },
+        { "name": "content", "label": "Content" },
+        { "name": "sidebar", "label": "Sidebar" }
+      ],
+      "defaultBlocks": [
+        { "region": "hero", "blockTypeSlug": "hero", "position": 0 },
+        { "region": "content", "blockTypeSlug": "rich_text", "position": 0 }
+      ],
+      "settings": {}
+    }
+  ],
+  "taxonomies": [
+    {
+      "id": 1,
+      "name": "Tags",
+      "slug": "tags",
+      "description": "Free-tagging vocabulary for content categorization",
+      "hierarchical": false
+    },
+    {
+      "id": 2,
+      "name": "Content Category",
+      "slug": "content_category",
+      "description": "Hierarchical content categories — similar to Drupal vocabularies",
+      "hierarchical": true
+    }
+  ],
+  "terms": [
+    { "id": 1, "taxonomyId": 1, "name": "drupal", "slug": "drupal", "weight": 0 },
+    { "id": 2, "taxonomyId": 1, "name": "migration", "slug": "migration", "weight": 1 },
+    { "id": 3, "taxonomyId": 1, "name": "cms", "slug": "cms", "weight": 2 },
+    { "id": 4, "taxonomyId": 1, "name": "web-development", "slug": "web-development", "weight": 3 },
+    { "id": 5, "taxonomyId": 2, "name": "News", "slug": "news", "weight": 0 },
+    { "id": 6, "taxonomyId": 2, "name": "Events", "slug": "events", "weight": 1 },
+    { "id": 7, "taxonomyId": 2, "name": "Resources", "slug": "resources", "weight": 2 }
+  ],
+  "pages": [
+    {
+      "id": 1,
+      "typeId": 3,
+      "title": "Home",
+      "slug": "home",
+      "status": "published",
+      "locale": "en",
+      "fields": {},
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z",
+      "publishedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 2,
+      "typeId": 2,
+      "title": "About",
+      "slug": "about",
+      "status": "published",
+      "locale": "en",
+      "fields": {},
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z",
+      "publishedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 3,
+      "typeId": 2,
+      "title": "News",
+      "slug": "news",
+      "status": "published",
+      "locale": "en",
+      "fields": {},
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z",
+      "publishedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 4,
+      "typeId": 2,
+      "title": "Events",
+      "slug": "events",
+      "status": "published",
+      "locale": "en",
+      "fields": {},
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z",
+      "publishedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 5,
+      "typeId": 2,
+      "title": "Contact",
+      "slug": "contact",
+      "status": "published",
+      "locale": "en",
+      "fields": {},
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z",
+      "publishedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 6,
+      "typeId": 1,
+      "title": "Migrating from Drupal to WollyCMS",
+      "slug": "migrating-from-drupal-to-wollycms",
+      "status": "published",
+      "locale": "en",
+      "fields": {
+        "body_summary": "A practical guide for Drupal administrators making the transition to a headless CMS.",
+        "author": "Admin",
+        "tags": "drupal, migration, cms",
+        "published_date": "2026-01-01"
+      },
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z",
+      "publishedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 7,
+      "typeId": 1,
+      "title": "Understanding Content Types and Regions",
+      "slug": "understanding-content-types-and-regions",
+      "status": "published",
+      "locale": "en",
+      "fields": {
+        "body_summary": "How WollyCMS content types and regions map to Drupal concepts you already know.",
+        "author": "Admin",
+        "tags": "cms, web-development",
+        "published_date": "2026-01-05"
+      },
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z",
+      "publishedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 8,
+      "typeId": 1,
+      "title": "Building Views with Content Listings",
+      "slug": "building-views-with-content-listings",
+      "status": "published",
+      "locale": "en",
+      "fields": {
+        "body_summary": "Replicate Drupal Views functionality using WollyCMS content listing blocks.",
+        "author": "Admin",
+        "tags": "drupal, web-development",
+        "published_date": "2026-01-10"
+      },
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z",
+      "publishedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 9,
+      "typeId": 4,
+      "title": "CMS Migration Workshop",
+      "slug": "cms-migration-workshop",
+      "status": "published",
+      "locale": "en",
+      "fields": {
+        "event_date": "2026-03-15",
+        "event_time": "10:00 AM - 2:00 PM",
+        "location": "Virtual (Zoom)",
+        "registration_url": "https://example.com/register"
+      },
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z",
+      "publishedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 10,
+      "typeId": 4,
+      "title": "Headless CMS Community Meetup",
+      "slug": "headless-cms-community-meetup",
+      "status": "published",
+      "locale": "en",
+      "fields": {
+        "event_date": "2026-04-20",
+        "event_time": "6:00 PM - 8:00 PM",
+        "location": "Community Center, 123 Main St",
+        "registration_url": "https://example.com/meetup"
+      },
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z",
+      "publishedAt": "2026-01-01T00:00:00.000Z"
+    }
+  ],
+  "blocks": [
+    {
+      "id": 1,
+      "typeId": 2,
+      "title": "Home Hero",
+      "fields": {
+        "heading": "Welcome to Our Organization",
+        "subheading": "Powered by a modern headless CMS — familiar structure, better performance",
+        "background_image": ""
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 2,
+      "typeId": 8,
+      "title": "Home Content Listing",
+      "fields": {
+        "content_type": "article",
+        "limit": 5,
+        "taxonomy_filter": "",
+        "display_style": "cards"
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 3,
+      "typeId": 2,
+      "title": "About Hero",
+      "fields": {
+        "heading": "About Us",
+        "subheading": "Our mission, history, and team",
+        "background_image": ""
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 4,
+      "typeId": 1,
+      "title": "About Content",
+      "fields": {
+        "body": {
+          "type": "doc",
+          "content": [
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "We are an organization committed to delivering excellent digital experiences. Our site has been migrated from Drupal to WollyCMS, giving us the familiar content structure we relied on with the performance benefits of a headless architecture." }]
+            },
+            {
+              "type": "heading",
+              "attrs": { "level": 2 },
+              "content": [{ "type": "text", "text": "Our History" }]
+            },
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "Founded with a focus on open-source technology, we have always valued flexibility and community-driven development." }]
+            }
+          ]
+        }
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 5,
+      "typeId": 2,
+      "title": "News Hero",
+      "fields": {
+        "heading": "News",
+        "subheading": "The latest articles and announcements",
+        "background_image": ""
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 6,
+      "typeId": 8,
+      "title": "News Content Listing",
+      "fields": {
+        "content_type": "article",
+        "limit": 10,
+        "taxonomy_filter": "news",
+        "display_style": "list"
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 7,
+      "typeId": 2,
+      "title": "Events Hero",
+      "fields": {
+        "heading": "Events",
+        "subheading": "Upcoming workshops, meetups, and conferences",
+        "background_image": ""
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 8,
+      "typeId": 8,
+      "title": "Events Content Listing",
+      "fields": {
+        "content_type": "event",
+        "limit": 10,
+        "taxonomy_filter": "",
+        "display_style": "cards"
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 9,
+      "typeId": 2,
+      "title": "Contact Hero",
+      "fields": {
+        "heading": "Contact Us",
+        "subheading": "Get in touch with our team",
+        "background_image": ""
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 10,
+      "typeId": 6,
+      "title": "Contact List",
+      "fields": {
+        "contacts": [
+          { "name": "General Inquiries", "title": "Main Office", "email": "info@example.com", "phone": "(555) 123-4567" },
+          { "name": "Technical Support", "title": "IT Department", "email": "support@example.com", "phone": "(555) 123-4568" }
+        ]
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 11,
+      "typeId": 7,
+      "title": "Contact Location",
+      "fields": {
+        "name": "Main Office",
+        "address": "123 Main Street\nSuite 100\nAnytown, ST 12345",
+        "latitude": "40.7128",
+        "longitude": "-74.0060",
+        "map_embed": ""
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 12,
+      "typeId": 2,
+      "title": "Article 1 Hero",
+      "fields": {
+        "heading": "Migrating from Drupal to WollyCMS",
+        "subheading": "A practical guide for Drupal administrators",
+        "background_image": ""
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 13,
+      "typeId": 1,
+      "title": "Article 1 Content",
+      "fields": {
+        "body": {
+          "type": "doc",
+          "content": [
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "If you are a Drupal site administrator considering a move to a headless CMS, WollyCMS offers a familiar content modeling approach. Content types, taxonomies, and regions map closely to Drupal concepts." }]
+            },
+            {
+              "type": "heading",
+              "attrs": { "level": 2 },
+              "content": [{ "type": "text", "text": "Content Types" }]
+            },
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "WollyCMS content types work like Drupal content types. Each has a set of fields and regions. Regions are similar to Drupal block regions — named areas where you place content blocks." }]
+            },
+            {
+              "type": "heading",
+              "attrs": { "level": 2 },
+              "content": [{ "type": "text", "text": "Taxonomy Vocabularies" }]
+            },
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "WollyCMS taxonomies are directly equivalent to Drupal vocabularies. They can be flat or hierarchical, and terms are used to categorize content." }]
+            }
+          ]
+        }
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 14,
+      "typeId": 2,
+      "title": "Article 2 Hero",
+      "fields": {
+        "heading": "Understanding Content Types and Regions",
+        "subheading": "Mapping Drupal concepts to WollyCMS",
+        "background_image": ""
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 15,
+      "typeId": 1,
+      "title": "Article 2 Content",
+      "fields": {
+        "body": {
+          "type": "doc",
+          "content": [
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "In Drupal, content types define the structure of your content. WollyCMS takes a similar approach, but adds the concept of regions — named areas within a page where blocks are placed." }]
+            },
+            {
+              "type": "heading",
+              "attrs": { "level": 2 },
+              "content": [{ "type": "text", "text": "Regions vs. Drupal Block Regions" }]
+            },
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "Drupal has site-wide block regions defined by themes. WollyCMS regions are per-content-type, giving you more granular control over layout without needing a theme layer." }]
+            }
+          ]
+        }
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 16,
+      "typeId": 2,
+      "title": "Article 3 Hero",
+      "fields": {
+        "heading": "Building Views with Content Listings",
+        "subheading": "Replicate Drupal Views in WollyCMS",
+        "background_image": ""
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 17,
+      "typeId": 1,
+      "title": "Article 3 Content",
+      "fields": {
+        "body": {
+          "type": "doc",
+          "content": [
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "Drupal Views is one of the most powerful modules in the Drupal ecosystem. WollyCMS provides a content listing block type that covers the most common use cases: listing content by type, filtering by taxonomy, and controlling display style." }]
+            },
+            {
+              "type": "heading",
+              "attrs": { "level": 2 },
+              "content": [{ "type": "text", "text": "Content Listing Blocks" }]
+            },
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "Add a content listing block to any region. Configure the content type to list, the number of items, an optional taxonomy filter, and the display style (list, grid, or cards)." }]
+            }
+          ]
+        }
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 18,
+      "typeId": 2,
+      "title": "Event 1 Hero",
+      "fields": {
+        "heading": "CMS Migration Workshop",
+        "subheading": "Hands-on workshop for migrating to WollyCMS",
+        "background_image": ""
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 19,
+      "typeId": 1,
+      "title": "Event 1 Content",
+      "fields": {
+        "body": {
+          "type": "doc",
+          "content": [
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "Join us for a hands-on workshop covering the complete migration process from Drupal to WollyCMS. We will walk through content export, schema mapping, data import, and frontend integration." }]
+            },
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "This virtual workshop is suitable for developers and site administrators. No prior WollyCMS experience required." }]
+            }
+          ]
+        }
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 20,
+      "typeId": 2,
+      "title": "Event 2 Hero",
+      "fields": {
+        "heading": "Headless CMS Community Meetup",
+        "subheading": "Connect with fellow CMS enthusiasts",
+        "background_image": ""
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 21,
+      "typeId": 1,
+      "title": "Event 2 Content",
+      "fields": {
+        "body": {
+          "type": "doc",
+          "content": [
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "Our monthly community meetup brings together developers, content strategists, and site administrators interested in headless CMS architecture. Share your experiences, ask questions, and learn from the community." }]
+            }
+          ]
+        }
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    }
+  ],
+  "pageBlocks": [
+    { "id": 1, "pageId": 1, "blockId": 1, "region": "hero", "position": 0, "isShared": false },
+    { "id": 2, "pageId": 1, "blockId": 2, "region": "content", "position": 0, "isShared": false },
+    { "id": 3, "pageId": 2, "blockId": 3, "region": "hero", "position": 0, "isShared": false },
+    { "id": 4, "pageId": 2, "blockId": 4, "region": "content", "position": 0, "isShared": false },
+    { "id": 5, "pageId": 3, "blockId": 5, "region": "hero", "position": 0, "isShared": false },
+    { "id": 6, "pageId": 3, "blockId": 6, "region": "content", "position": 0, "isShared": false },
+    { "id": 7, "pageId": 4, "blockId": 7, "region": "hero", "position": 0, "isShared": false },
+    { "id": 8, "pageId": 4, "blockId": 8, "region": "content", "position": 0, "isShared": false },
+    { "id": 9, "pageId": 5, "blockId": 9, "region": "hero", "position": 0, "isShared": false },
+    { "id": 10, "pageId": 5, "blockId": 10, "region": "content", "position": 0, "isShared": false },
+    { "id": 11, "pageId": 5, "blockId": 11, "region": "bottom", "position": 0, "isShared": false },
+    { "id": 12, "pageId": 6, "blockId": 12, "region": "hero", "position": 0, "isShared": false },
+    { "id": 13, "pageId": 6, "blockId": 13, "region": "content", "position": 0, "isShared": false },
+    { "id": 14, "pageId": 7, "blockId": 14, "region": "hero", "position": 0, "isShared": false },
+    { "id": 15, "pageId": 7, "blockId": 15, "region": "content", "position": 0, "isShared": false },
+    { "id": 16, "pageId": 8, "blockId": 16, "region": "hero", "position": 0, "isShared": false },
+    { "id": 17, "pageId": 8, "blockId": 17, "region": "content", "position": 0, "isShared": false },
+    { "id": 18, "pageId": 9, "blockId": 18, "region": "hero", "position": 0, "isShared": false },
+    { "id": 19, "pageId": 9, "blockId": 19, "region": "content", "position": 0, "isShared": false },
+    { "id": 20, "pageId": 10, "blockId": 20, "region": "hero", "position": 0, "isShared": false },
+    { "id": 21, "pageId": 10, "blockId": 21, "region": "content", "position": 0, "isShared": false }
+  ],
+  "menus": [
+    { "id": 1, "name": "Main Navigation", "slug": "main-nav" }
+  ],
+  "menuItems": [
+    { "id": 1, "menuId": 1, "title": "Home", "url": "/", "pageId": 1, "target": "_self", "position": 0, "depth": 0, "parentId": null, "isExpanded": false, "attributes": {} },
+    { "id": 2, "menuId": 1, "title": "About", "url": "/about", "pageId": 2, "target": "_self", "position": 1, "depth": 0, "parentId": null, "isExpanded": false, "attributes": {} },
+    { "id": 3, "menuId": 1, "title": "News", "url": "/news", "pageId": 3, "target": "_self", "position": 2, "depth": 0, "parentId": null, "isExpanded": false, "attributes": {} },
+    { "id": 4, "menuId": 1, "title": "Events", "url": "/events", "pageId": 4, "target": "_self", "position": 3, "depth": 0, "parentId": null, "isExpanded": false, "attributes": {} },
+    { "id": 5, "menuId": 1, "title": "Contact", "url": "/contact", "pageId": 5, "target": "_self", "position": 4, "depth": 0, "parentId": null, "isExpanded": false, "attributes": {} }
+  ]
+}

--- a/templates/marketing/README.md
+++ b/templates/marketing/README.md
@@ -1,0 +1,43 @@
+# WollyCMS Marketing Template
+
+A product or business marketing site with feature grids, stats, pricing FAQ, and conversion-focused layouts.
+
+## What's included
+
+- 3 content types, 8 block types, 5 sample pages
+- Pre-configured main navigation menu
+- Home page with hero, feature grid, stats bar, and CTA
+- Features page with detailed feature grid and comparison content
+- Pricing page with accordion FAQ
+- Ready to customize
+
+## Quick start
+
+```bash
+npx create-wolly my-site --template marketing
+cd my-site
+wolly migrate
+wolly import templates/marketing/seed.json
+wolly start
+```
+
+## Content types
+
+| Content Type | Slug | Regions |
+|-------------|------|---------|
+| Home Page | `home_page` | hero, content, features, bottom |
+| Landing Page | `landing_page` | hero, content, features, bottom |
+| Page | `page` | hero, content, sidebar |
+
+## Block types
+
+| Block Type | Slug | Description |
+|-----------|------|-------------|
+| Rich Text | `rich_text` | TipTap rich text content |
+| Hero | `hero` | Banner with heading, subheading, and background image |
+| CTA Button | `cta_button` | Call-to-action button with configurable style |
+| Feature Grid | `feature_grid` | Grid of features with title, description, and icon |
+| Stat Bar | `stat_bar` | Row of statistics with values and labels |
+| Image | `image` | Single image with alt text and caption |
+| Accordion | `accordion` | Expandable FAQ or collapsible content sections |
+| Embed | `embed` | Embed external content via URL or HTML |

--- a/templates/marketing/seed.json
+++ b/templates/marketing/seed.json
@@ -1,0 +1,525 @@
+{
+  "version": 1,
+  "blockTypes": [
+    {
+      "id": 1,
+      "name": "Rich Text",
+      "slug": "rich_text",
+      "description": "A rich text content block using TipTap JSON format",
+      "fieldsSchema": [
+        { "name": "body", "label": "Body", "type": "richtext", "required": true }
+      ],
+      "icon": "text",
+      "settings": {},
+      "createdAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 2,
+      "name": "Hero",
+      "slug": "hero",
+      "description": "A hero banner with heading, subheading, and optional background image",
+      "fieldsSchema": [
+        { "name": "heading", "label": "Heading", "type": "text", "required": true },
+        { "name": "subheading", "label": "Subheading", "type": "text" },
+        { "name": "background_image", "label": "Background Image", "type": "media" }
+      ],
+      "icon": "layout",
+      "settings": {},
+      "createdAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 3,
+      "name": "CTA Button",
+      "slug": "cta_button",
+      "description": "A call-to-action button with configurable text, URL, and style",
+      "fieldsSchema": [
+        { "name": "text", "label": "Button Text", "type": "text", "required": true },
+        { "name": "url", "label": "URL", "type": "url", "required": true },
+        { "name": "style", "label": "Style", "type": "select", "options": ["primary", "secondary", "outline"] }
+      ],
+      "icon": "mouse-pointer",
+      "settings": {},
+      "createdAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 4,
+      "name": "Feature Grid",
+      "slug": "feature_grid",
+      "description": "A grid of features with title, description, and icon for each item",
+      "fieldsSchema": [
+        {
+          "name": "items",
+          "label": "Features",
+          "type": "repeater",
+          "fields": [
+            { "name": "title", "label": "Title", "type": "text" },
+            { "name": "description", "label": "Description", "type": "textarea" },
+            { "name": "icon", "label": "Icon", "type": "text" }
+          ]
+        }
+      ],
+      "icon": "grid",
+      "settings": {},
+      "createdAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 5,
+      "name": "Stat Bar",
+      "slug": "stat_bar",
+      "description": "A row of statistics with numbers and labels",
+      "fieldsSchema": [
+        {
+          "name": "stats",
+          "label": "Statistics",
+          "type": "repeater",
+          "fields": [
+            { "name": "value", "label": "Value", "type": "text" },
+            { "name": "label", "label": "Label", "type": "text" }
+          ]
+        }
+      ],
+      "icon": "bar-chart",
+      "settings": {},
+      "createdAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 6,
+      "name": "Image",
+      "slug": "image",
+      "description": "A single image with optional caption and alt text",
+      "fieldsSchema": [
+        { "name": "src", "label": "Image", "type": "media", "required": true },
+        { "name": "alt", "label": "Alt Text", "type": "text", "required": true },
+        { "name": "caption", "label": "Caption", "type": "text" }
+      ],
+      "icon": "image",
+      "settings": {},
+      "createdAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 7,
+      "name": "Accordion",
+      "slug": "accordion",
+      "description": "Expandable accordion sections for FAQs or collapsible content",
+      "fieldsSchema": [
+        {
+          "name": "items",
+          "label": "Accordion Items",
+          "type": "repeater",
+          "fields": [
+            { "name": "title", "label": "Title", "type": "text" },
+            { "name": "content", "label": "Content", "type": "textarea" }
+          ]
+        }
+      ],
+      "icon": "chevrons-down",
+      "settings": {},
+      "createdAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 8,
+      "name": "Embed",
+      "slug": "embed",
+      "description": "Embed external content via URL or HTML snippet",
+      "fieldsSchema": [
+        { "name": "embed_url", "label": "Embed URL", "type": "url" },
+        { "name": "embed_html", "label": "Embed HTML", "type": "textarea" },
+        { "name": "caption", "label": "Caption", "type": "text" }
+      ],
+      "icon": "code",
+      "settings": {},
+      "createdAt": "2026-01-01T00:00:00.000Z"
+    }
+  ],
+  "contentTypes": [
+    {
+      "id": 1,
+      "name": "Home Page",
+      "slug": "home_page",
+      "description": "The main homepage layout with hero, content, features, and bottom CTA",
+      "fieldsSchema": [],
+      "regions": [
+        { "name": "hero", "label": "Hero" },
+        { "name": "content", "label": "Content" },
+        { "name": "features", "label": "Features" },
+        { "name": "bottom", "label": "Bottom" }
+      ],
+      "defaultBlocks": [
+        { "region": "hero", "blockTypeSlug": "hero", "position": 0 },
+        { "region": "features", "blockTypeSlug": "feature_grid", "position": 0 },
+        { "region": "bottom", "blockTypeSlug": "cta_button", "position": 0 }
+      ],
+      "settings": {}
+    },
+    {
+      "id": 2,
+      "name": "Landing Page",
+      "slug": "landing_page",
+      "description": "A conversion-focused landing page with hero, content, features, and bottom sections",
+      "fieldsSchema": [],
+      "regions": [
+        { "name": "hero", "label": "Hero" },
+        { "name": "content", "label": "Content" },
+        { "name": "features", "label": "Features" },
+        { "name": "bottom", "label": "Bottom" }
+      ],
+      "defaultBlocks": [
+        { "region": "hero", "blockTypeSlug": "hero", "position": 0 },
+        { "region": "content", "blockTypeSlug": "rich_text", "position": 0 },
+        { "region": "bottom", "blockTypeSlug": "cta_button", "position": 0 }
+      ],
+      "settings": {}
+    },
+    {
+      "id": 3,
+      "name": "Page",
+      "slug": "page",
+      "description": "A general-purpose page with hero, content, and sidebar regions",
+      "fieldsSchema": [],
+      "regions": [
+        { "name": "hero", "label": "Hero" },
+        { "name": "content", "label": "Content" },
+        { "name": "sidebar", "label": "Sidebar" }
+      ],
+      "defaultBlocks": [
+        { "region": "hero", "blockTypeSlug": "hero", "position": 0 },
+        { "region": "content", "blockTypeSlug": "rich_text", "position": 0 }
+      ],
+      "settings": {}
+    }
+  ],
+  "taxonomies": [],
+  "terms": [],
+  "pages": [
+    {
+      "id": 1,
+      "typeId": 1,
+      "title": "Home",
+      "slug": "home",
+      "status": "published",
+      "locale": "en",
+      "fields": {},
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z",
+      "publishedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 2,
+      "typeId": 2,
+      "title": "Features",
+      "slug": "features",
+      "status": "published",
+      "locale": "en",
+      "fields": {},
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z",
+      "publishedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 3,
+      "typeId": 2,
+      "title": "Pricing",
+      "slug": "pricing",
+      "status": "published",
+      "locale": "en",
+      "fields": {},
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z",
+      "publishedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 4,
+      "typeId": 3,
+      "title": "About",
+      "slug": "about",
+      "status": "published",
+      "locale": "en",
+      "fields": {},
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z",
+      "publishedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 5,
+      "typeId": 3,
+      "title": "Contact",
+      "slug": "contact",
+      "status": "published",
+      "locale": "en",
+      "fields": {},
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z",
+      "publishedAt": "2026-01-01T00:00:00.000Z"
+    }
+  ],
+  "blocks": [
+    {
+      "id": 1,
+      "typeId": 2,
+      "title": "Home Hero",
+      "fields": {
+        "heading": "Build Something Amazing",
+        "subheading": "The all-in-one platform to launch, grow, and scale your business",
+        "background_image": ""
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 2,
+      "typeId": 4,
+      "title": "Home Features",
+      "fields": {
+        "items": [
+          { "title": "Lightning Fast", "description": "Built on edge infrastructure for sub-second response times worldwide.", "icon": "zap" },
+          { "title": "Easy to Use", "description": "Intuitive interface that your whole team can learn in minutes.", "icon": "smile" },
+          { "title": "Fully Customizable", "description": "Adapt every aspect to match your brand and workflow.", "icon": "sliders" },
+          { "title": "Secure by Default", "description": "Enterprise-grade security with encryption at rest and in transit.", "icon": "shield" }
+        ]
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 3,
+      "typeId": 5,
+      "title": "Home Stats",
+      "fields": {
+        "stats": [
+          { "value": "10K+", "label": "Active Users" },
+          { "value": "99.9%", "label": "Uptime" },
+          { "value": "50ms", "label": "Avg Response" },
+          { "value": "24/7", "label": "Support" }
+        ]
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 4,
+      "typeId": 3,
+      "title": "Home CTA",
+      "fields": {
+        "text": "Get Started Free",
+        "url": "/pricing",
+        "style": "primary"
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 5,
+      "typeId": 2,
+      "title": "Features Hero",
+      "fields": {
+        "heading": "Powerful Features",
+        "subheading": "Everything you need to build and manage your online presence",
+        "background_image": ""
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 6,
+      "typeId": 4,
+      "title": "Features Grid",
+      "fields": {
+        "items": [
+          { "title": "Block-Based Editor", "description": "Compose pages using reusable content blocks. Mix and match hero banners, text, images, CTAs, and more.", "icon": "layout" },
+          { "title": "Headless API", "description": "A clean REST API powers your frontend. Use Astro, Next.js, or any framework you prefer.", "icon": "code" },
+          { "title": "Media Management", "description": "Upload, crop, and optimize images automatically. Responsive image variants generated on the fly.", "icon": "image" },
+          { "title": "SEO Tools", "description": "Built-in meta tag management, OpenGraph previews, and sitemap generation.", "icon": "search" },
+          { "title": "Role-Based Access", "description": "Control who can create, edit, and publish content with granular permissions.", "icon": "users" },
+          { "title": "Multi-Language", "description": "Manage content in multiple languages with locale-aware routing and fallback.", "icon": "globe" }
+        ]
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 7,
+      "typeId": 1,
+      "title": "Features Comparison",
+      "fields": {
+        "body": {
+          "type": "doc",
+          "content": [
+            {
+              "type": "heading",
+              "attrs": { "level": 2 },
+              "content": [{ "type": "text", "text": "Why Choose Us?" }]
+            },
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "Unlike monolithic CMSs, our headless approach gives you complete control over your frontend. No theme lock-in, no plugin conflicts, no performance compromises." }]
+            }
+          ]
+        }
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 8,
+      "typeId": 2,
+      "title": "Pricing Hero",
+      "fields": {
+        "heading": "Simple, Transparent Pricing",
+        "subheading": "No hidden fees. No surprises. Start free and scale as you grow.",
+        "background_image": ""
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 9,
+      "typeId": 1,
+      "title": "Pricing Content",
+      "fields": {
+        "body": {
+          "type": "doc",
+          "content": [
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "Choose the plan that fits your needs. All plans include the core CMS features, API access, and community support." }]
+            }
+          ]
+        }
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 10,
+      "typeId": 7,
+      "title": "Pricing FAQ",
+      "fields": {
+        "items": [
+          { "title": "Can I try it for free?", "content": "Yes! Our free tier includes everything you need to get started. No credit card required." },
+          { "title": "Can I switch plans later?", "content": "Absolutely. Upgrade or downgrade at any time. Changes take effect on your next billing cycle." },
+          { "title": "Is there a setup fee?", "content": "No setup fees. You only pay the monthly subscription price." },
+          { "title": "Do you offer custom enterprise plans?", "content": "Yes. Contact us for custom pricing, SLAs, and dedicated support options." }
+        ]
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 11,
+      "typeId": 2,
+      "title": "About Hero",
+      "fields": {
+        "heading": "About Us",
+        "subheading": "The team and mission behind the product",
+        "background_image": ""
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 12,
+      "typeId": 1,
+      "title": "About Content",
+      "fields": {
+        "body": {
+          "type": "doc",
+          "content": [
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "We believe content management should be simple, fast, and flexible. Our platform is built by developers for developers, with a content editing experience that non-technical users love." }]
+            },
+            {
+              "type": "heading",
+              "attrs": { "level": 2 },
+              "content": [{ "type": "text", "text": "Our Mission" }]
+            },
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "To give every team the tools to build exceptional web experiences without compromising on performance, security, or developer happiness." }]
+            }
+          ]
+        }
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 13,
+      "typeId": 2,
+      "title": "Contact Hero",
+      "fields": {
+        "heading": "Get in Touch",
+        "subheading": "Have questions? We would love to hear from you.",
+        "background_image": ""
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 14,
+      "typeId": 1,
+      "title": "Contact Content",
+      "fields": {
+        "body": {
+          "type": "doc",
+          "content": [
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "Reach out to our team for sales inquiries, technical support, or partnership opportunities. We typically respond within one business day." }]
+            },
+            {
+              "type": "heading",
+              "attrs": { "level": 2 },
+              "content": [{ "type": "text", "text": "Email" }]
+            },
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "hello@example.com" }]
+            }
+          ]
+        }
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    }
+  ],
+  "pageBlocks": [
+    { "id": 1, "pageId": 1, "blockId": 1, "region": "hero", "position": 0, "isShared": false },
+    { "id": 2, "pageId": 1, "blockId": 2, "region": "features", "position": 0, "isShared": false },
+    { "id": 3, "pageId": 1, "blockId": 3, "region": "content", "position": 0, "isShared": false },
+    { "id": 4, "pageId": 1, "blockId": 4, "region": "bottom", "position": 0, "isShared": false },
+    { "id": 5, "pageId": 2, "blockId": 5, "region": "hero", "position": 0, "isShared": false },
+    { "id": 6, "pageId": 2, "blockId": 6, "region": "features", "position": 0, "isShared": false },
+    { "id": 7, "pageId": 2, "blockId": 7, "region": "content", "position": 0, "isShared": false },
+    { "id": 8, "pageId": 3, "blockId": 8, "region": "hero", "position": 0, "isShared": false },
+    { "id": 9, "pageId": 3, "blockId": 9, "region": "content", "position": 0, "isShared": false },
+    { "id": 10, "pageId": 3, "blockId": 10, "region": "features", "position": 0, "isShared": false },
+    { "id": 11, "pageId": 4, "blockId": 11, "region": "hero", "position": 0, "isShared": false },
+    { "id": 12, "pageId": 4, "blockId": 12, "region": "content", "position": 0, "isShared": false },
+    { "id": 13, "pageId": 5, "blockId": 13, "region": "hero", "position": 0, "isShared": false },
+    { "id": 14, "pageId": 5, "blockId": 14, "region": "content", "position": 0, "isShared": false }
+  ],
+  "menus": [
+    { "id": 1, "name": "Main Navigation", "slug": "main-nav" }
+  ],
+  "menuItems": [
+    { "id": 1, "menuId": 1, "title": "Features", "url": "/features", "pageId": 2, "target": "_self", "position": 0, "depth": 0, "parentId": null, "isExpanded": false, "attributes": {} },
+    { "id": 2, "menuId": 1, "title": "Pricing", "url": "/pricing", "pageId": 3, "target": "_self", "position": 1, "depth": 0, "parentId": null, "isExpanded": false, "attributes": {} },
+    { "id": 3, "menuId": 1, "title": "About", "url": "/about", "pageId": 4, "target": "_self", "position": 2, "depth": 0, "parentId": null, "isExpanded": false, "attributes": {} },
+    { "id": 4, "menuId": 1, "title": "Contact", "url": "/contact", "pageId": 5, "target": "_self", "position": 3, "depth": 0, "parentId": null, "isExpanded": false, "attributes": {} }
+  ]
+}

--- a/templates/wordpress/README.md
+++ b/templates/wordpress/README.md
@@ -1,0 +1,53 @@
+# WollyCMS WordPress Template
+
+A familiar starting point for WordPress users migrating to WollyCMS, with posts, pages, categories, and tags.
+
+## What's included
+
+- 2 content types, 5 block types, 8 sample pages
+- Pre-configured taxonomies (Categories: Uncategorized, News, Tutorials; Tags: wordpress, migration, cms)
+- Main navigation (Home, Blog, About, Contact) and Footer navigation (Privacy Policy, About)
+- 3 sample posts including a migration guide
+- Classic WordPress-style post/page structure
+- Ready to customize
+
+## Quick start
+
+```bash
+npx create-wolly my-site --template wordpress
+cd my-site
+wolly migrate
+wolly import templates/wordpress/seed.json
+wolly start
+```
+
+## Content types
+
+| Content Type | Slug | Regions |
+|-------------|------|---------|
+| Post | `post` | content, sidebar |
+| Page | `page` | hero, content, sidebar |
+
+**Post fields:** excerpt, author, categories, featured_image, published_date
+
+## Block types
+
+| Block Type | Slug | Description |
+|-----------|------|-------------|
+| Rich Text | `rich_text` | TipTap rich text content |
+| Hero | `hero` | Banner with heading, subheading, and background image |
+| Image | `image` | Single image with alt text and caption |
+| CTA Button | `cta_button` | Call-to-action button with configurable style |
+| Embed | `embed` | Embed external content via URL or HTML |
+
+## WordPress concepts mapped to WollyCMS
+
+| WordPress | WollyCMS |
+|-----------|----------|
+| Posts | Content type `post` |
+| Pages | Content type `page` |
+| Categories | Taxonomy `categories` (hierarchical) |
+| Tags | Taxonomy `tags` (flat) |
+| Featured Image | Field `featured_image` on post |
+| Gutenberg Blocks | Content blocks (rich_text, hero, image, etc.) |
+| Menus | Menus with menu items |

--- a/templates/wordpress/seed.json
+++ b/templates/wordpress/seed.json
@@ -1,0 +1,558 @@
+{
+  "version": 1,
+  "blockTypes": [
+    {
+      "id": 1,
+      "name": "Rich Text",
+      "slug": "rich_text",
+      "description": "A rich text content block using TipTap JSON format",
+      "fieldsSchema": [
+        { "name": "body", "label": "Body", "type": "richtext", "required": true }
+      ],
+      "icon": "text",
+      "settings": {},
+      "createdAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 2,
+      "name": "Hero",
+      "slug": "hero",
+      "description": "A hero banner with heading, subheading, and optional background image",
+      "fieldsSchema": [
+        { "name": "heading", "label": "Heading", "type": "text", "required": true },
+        { "name": "subheading", "label": "Subheading", "type": "text" },
+        { "name": "background_image", "label": "Background Image", "type": "media" }
+      ],
+      "icon": "layout",
+      "settings": {},
+      "createdAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 3,
+      "name": "Image",
+      "slug": "image",
+      "description": "A single image with optional caption and alt text",
+      "fieldsSchema": [
+        { "name": "src", "label": "Image", "type": "media", "required": true },
+        { "name": "alt", "label": "Alt Text", "type": "text", "required": true },
+        { "name": "caption", "label": "Caption", "type": "text" }
+      ],
+      "icon": "image",
+      "settings": {},
+      "createdAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 4,
+      "name": "CTA Button",
+      "slug": "cta_button",
+      "description": "A call-to-action button with configurable text, URL, and style",
+      "fieldsSchema": [
+        { "name": "text", "label": "Button Text", "type": "text", "required": true },
+        { "name": "url", "label": "URL", "type": "url", "required": true },
+        { "name": "style", "label": "Style", "type": "select", "options": ["primary", "secondary", "outline"] }
+      ],
+      "icon": "mouse-pointer",
+      "settings": {},
+      "createdAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 5,
+      "name": "Embed",
+      "slug": "embed",
+      "description": "Embed external content via URL or HTML snippet",
+      "fieldsSchema": [
+        { "name": "embed_url", "label": "Embed URL", "type": "url" },
+        { "name": "embed_html", "label": "Embed HTML", "type": "textarea" },
+        { "name": "caption", "label": "Caption", "type": "text" }
+      ],
+      "icon": "code",
+      "settings": {},
+      "createdAt": "2026-01-01T00:00:00.000Z"
+    }
+  ],
+  "contentTypes": [
+    {
+      "id": 1,
+      "name": "Post",
+      "slug": "post",
+      "description": "A blog post — similar to WordPress posts with excerpt, author, and categories",
+      "fieldsSchema": [
+        { "name": "excerpt", "label": "Excerpt", "type": "textarea" },
+        { "name": "author", "label": "Author", "type": "text" },
+        { "name": "categories", "label": "Categories", "type": "text" },
+        { "name": "featured_image", "label": "Featured Image", "type": "media" },
+        { "name": "published_date", "label": "Published Date", "type": "date" }
+      ],
+      "regions": [
+        { "name": "content", "label": "Content" },
+        { "name": "sidebar", "label": "Sidebar" }
+      ],
+      "defaultBlocks": [
+        { "region": "content", "blockTypeSlug": "rich_text", "position": 0 }
+      ],
+      "settings": {}
+    },
+    {
+      "id": 2,
+      "name": "Page",
+      "slug": "page",
+      "description": "A static page — similar to WordPress pages with hero, content, and sidebar",
+      "fieldsSchema": [],
+      "regions": [
+        { "name": "hero", "label": "Hero" },
+        { "name": "content", "label": "Content" },
+        { "name": "sidebar", "label": "Sidebar" }
+      ],
+      "defaultBlocks": [
+        { "region": "hero", "blockTypeSlug": "hero", "position": 0 },
+        { "region": "content", "blockTypeSlug": "rich_text", "position": 0 }
+      ],
+      "settings": {}
+    }
+  ],
+  "taxonomies": [
+    {
+      "id": 1,
+      "name": "Categories",
+      "slug": "categories",
+      "description": "Post categories — hierarchical, like WordPress categories",
+      "hierarchical": true
+    },
+    {
+      "id": 2,
+      "name": "Tags",
+      "slug": "tags",
+      "description": "Post tags — flat taxonomy for flexible labeling",
+      "hierarchical": false
+    }
+  ],
+  "terms": [
+    { "id": 1, "taxonomyId": 1, "name": "Uncategorized", "slug": "uncategorized", "weight": 0 },
+    { "id": 2, "taxonomyId": 1, "name": "News", "slug": "news", "weight": 1 },
+    { "id": 3, "taxonomyId": 1, "name": "Tutorials", "slug": "tutorials", "weight": 2 },
+    { "id": 4, "taxonomyId": 2, "name": "wordpress", "slug": "wordpress", "weight": 0 },
+    { "id": 5, "taxonomyId": 2, "name": "migration", "slug": "migration", "weight": 1 },
+    { "id": 6, "taxonomyId": 2, "name": "cms", "slug": "cms", "weight": 2 }
+  ],
+  "pages": [
+    {
+      "id": 1,
+      "typeId": 2,
+      "title": "Home",
+      "slug": "home",
+      "status": "published",
+      "locale": "en",
+      "fields": {},
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z",
+      "publishedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 2,
+      "typeId": 2,
+      "title": "Blog",
+      "slug": "blog",
+      "status": "published",
+      "locale": "en",
+      "fields": {},
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z",
+      "publishedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 3,
+      "typeId": 2,
+      "title": "About",
+      "slug": "about",
+      "status": "published",
+      "locale": "en",
+      "fields": {},
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z",
+      "publishedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 4,
+      "typeId": 2,
+      "title": "Contact",
+      "slug": "contact",
+      "status": "published",
+      "locale": "en",
+      "fields": {},
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z",
+      "publishedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 5,
+      "typeId": 2,
+      "title": "Privacy Policy",
+      "slug": "privacy-policy",
+      "status": "published",
+      "locale": "en",
+      "fields": {},
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z",
+      "publishedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 6,
+      "typeId": 1,
+      "title": "Hello World",
+      "slug": "hello-world",
+      "status": "published",
+      "locale": "en",
+      "fields": {
+        "excerpt": "Welcome to your new site! This is your first post. Edit or delete it, then start writing.",
+        "author": "Admin",
+        "categories": "Uncategorized",
+        "featured_image": "",
+        "published_date": "2026-01-01"
+      },
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z",
+      "publishedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 7,
+      "typeId": 1,
+      "title": "Migrating from WordPress to WollyCMS",
+      "slug": "migrating-from-wordpress-to-wollycms",
+      "status": "published",
+      "locale": "en",
+      "fields": {
+        "excerpt": "A step-by-step guide for WordPress users making the switch to a headless CMS.",
+        "author": "Admin",
+        "categories": "Tutorials",
+        "featured_image": "",
+        "published_date": "2026-01-05"
+      },
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z",
+      "publishedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 8,
+      "typeId": 1,
+      "title": "Understanding Content Blocks",
+      "slug": "understanding-content-blocks",
+      "status": "published",
+      "locale": "en",
+      "fields": {
+        "excerpt": "How WollyCMS blocks compare to the WordPress block editor and what makes them different.",
+        "author": "Admin",
+        "categories": "News",
+        "featured_image": "",
+        "published_date": "2026-01-10"
+      },
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z",
+      "publishedAt": "2026-01-01T00:00:00.000Z"
+    }
+  ],
+  "blocks": [
+    {
+      "id": 1,
+      "typeId": 2,
+      "title": "Home Hero",
+      "fields": {
+        "heading": "Welcome to Your New Site",
+        "subheading": "Powered by WollyCMS — a modern headless CMS that feels familiar",
+        "background_image": ""
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 2,
+      "typeId": 1,
+      "title": "Home Content",
+      "fields": {
+        "body": {
+          "type": "doc",
+          "content": [
+            {
+              "type": "heading",
+              "attrs": { "level": 2 },
+              "content": [{ "type": "text", "text": "Latest Posts" }]
+            },
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "Welcome to your new site. If you are coming from WordPress, you will feel right at home. Posts, pages, categories, and tags all work the way you expect — with the added power of a headless CMS." }]
+            }
+          ]
+        }
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 3,
+      "typeId": 2,
+      "title": "Blog Hero",
+      "fields": {
+        "heading": "Blog",
+        "subheading": "All the latest posts and updates",
+        "background_image": ""
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 4,
+      "typeId": 1,
+      "title": "Blog Content",
+      "fields": {
+        "body": {
+          "type": "doc",
+          "content": [
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "Browse our latest articles below. Use categories and tags to find topics that interest you." }]
+            }
+          ]
+        }
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 5,
+      "typeId": 2,
+      "title": "About Hero",
+      "fields": {
+        "heading": "About Us",
+        "subheading": "Who we are and what we do",
+        "background_image": ""
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 6,
+      "typeId": 1,
+      "title": "About Content",
+      "fields": {
+        "body": {
+          "type": "doc",
+          "content": [
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "This site is powered by WollyCMS, a headless content management system. We migrated from WordPress and have not looked back." }]
+            },
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "With WollyCMS, we get the content editing experience we loved in WordPress combined with the performance and flexibility of a modern headless architecture." }]
+            }
+          ]
+        }
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 7,
+      "typeId": 2,
+      "title": "Contact Hero",
+      "fields": {
+        "heading": "Contact Us",
+        "subheading": "Get in touch — we would love to hear from you",
+        "background_image": ""
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 8,
+      "typeId": 1,
+      "title": "Contact Content",
+      "fields": {
+        "body": {
+          "type": "doc",
+          "content": [
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "Have a question or want to get in touch? Send us an email at hello@example.com and we will get back to you as soon as possible." }]
+            }
+          ]
+        }
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 9,
+      "typeId": 2,
+      "title": "Privacy Hero",
+      "fields": {
+        "heading": "Privacy Policy",
+        "subheading": "",
+        "background_image": ""
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 10,
+      "typeId": 1,
+      "title": "Privacy Content",
+      "fields": {
+        "body": {
+          "type": "doc",
+          "content": [
+            {
+              "type": "heading",
+              "attrs": { "level": 2 },
+              "content": [{ "type": "text", "text": "What Data We Collect" }]
+            },
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "This is a sample privacy policy. Replace this content with your actual privacy policy that describes what data you collect, how you use it, and how users can request its deletion." }]
+            },
+            {
+              "type": "heading",
+              "attrs": { "level": 2 },
+              "content": [{ "type": "text", "text": "How We Use Your Data" }]
+            },
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "Describe how collected data is processed, stored, and shared with third parties if applicable." }]
+            }
+          ]
+        }
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 11,
+      "typeId": 1,
+      "title": "Hello World Content",
+      "fields": {
+        "body": {
+          "type": "doc",
+          "content": [
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "Welcome to WollyCMS! This is your first post. Edit or delete it, then start writing." }]
+            },
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "If you are coming from WordPress, you will notice that WollyCMS uses a similar posts and pages model. Create posts for your blog content and pages for static content like About or Contact." }]
+            }
+          ]
+        }
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 12,
+      "typeId": 1,
+      "title": "Migration Guide Content",
+      "fields": {
+        "body": {
+          "type": "doc",
+          "content": [
+            {
+              "type": "heading",
+              "attrs": { "level": 2 },
+              "content": [{ "type": "text", "text": "Before You Start" }]
+            },
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "Export your WordPress content using the built-in export tool. WollyCMS can import your posts, pages, categories, and tags — preserving your content structure." }]
+            },
+            {
+              "type": "heading",
+              "attrs": { "level": 2 },
+              "content": [{ "type": "text", "text": "Step 1: Export from WordPress" }]
+            },
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "Go to Tools > Export in your WordPress dashboard. Select All Content and download the XML file." }]
+            },
+            {
+              "type": "heading",
+              "attrs": { "level": 2 },
+              "content": [{ "type": "text", "text": "Step 2: Import into WollyCMS" }]
+            },
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "Use the wolly import command to bring your content into WollyCMS. The importer maps WordPress post types to WollyCMS content types automatically." }]
+            }
+          ]
+        }
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    },
+    {
+      "id": 13,
+      "typeId": 1,
+      "title": "Content Blocks Content",
+      "fields": {
+        "body": {
+          "type": "doc",
+          "content": [
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "If you have used the WordPress block editor (Gutenberg), WollyCMS blocks will feel familiar. The key difference is that WollyCMS blocks are stored as structured data, not rendered HTML." }]
+            },
+            {
+              "type": "heading",
+              "attrs": { "level": 2 },
+              "content": [{ "type": "text", "text": "What Are Content Blocks?" }]
+            },
+            {
+              "type": "paragraph",
+              "content": [{ "type": "text", "text": "Content blocks are reusable pieces of structured content. Each block has a type (like Rich Text, Hero, or Image), a set of fields defined by its schema, and can be placed in any region of a page." }]
+            }
+          ]
+        }
+      },
+      "isReusable": false,
+      "createdAt": "2026-01-01T00:00:00.000Z",
+      "updatedAt": "2026-01-01T00:00:00.000Z"
+    }
+  ],
+  "pageBlocks": [
+    { "id": 1, "pageId": 1, "blockId": 1, "region": "hero", "position": 0, "isShared": false },
+    { "id": 2, "pageId": 1, "blockId": 2, "region": "content", "position": 0, "isShared": false },
+    { "id": 3, "pageId": 2, "blockId": 3, "region": "hero", "position": 0, "isShared": false },
+    { "id": 4, "pageId": 2, "blockId": 4, "region": "content", "position": 0, "isShared": false },
+    { "id": 5, "pageId": 3, "blockId": 5, "region": "hero", "position": 0, "isShared": false },
+    { "id": 6, "pageId": 3, "blockId": 6, "region": "content", "position": 0, "isShared": false },
+    { "id": 7, "pageId": 4, "blockId": 7, "region": "hero", "position": 0, "isShared": false },
+    { "id": 8, "pageId": 4, "blockId": 8, "region": "content", "position": 0, "isShared": false },
+    { "id": 9, "pageId": 5, "blockId": 9, "region": "hero", "position": 0, "isShared": false },
+    { "id": 10, "pageId": 5, "blockId": 10, "region": "content", "position": 0, "isShared": false },
+    { "id": 11, "pageId": 6, "blockId": 11, "region": "content", "position": 0, "isShared": false },
+    { "id": 12, "pageId": 7, "blockId": 12, "region": "content", "position": 0, "isShared": false },
+    { "id": 13, "pageId": 8, "blockId": 13, "region": "content", "position": 0, "isShared": false }
+  ],
+  "menus": [
+    { "id": 1, "name": "Main Navigation", "slug": "main-nav" },
+    { "id": 2, "name": "Footer Navigation", "slug": "footer-nav" }
+  ],
+  "menuItems": [
+    { "id": 1, "menuId": 1, "title": "Home", "url": "/", "pageId": 1, "target": "_self", "position": 0, "depth": 0, "parentId": null, "isExpanded": false, "attributes": {} },
+    { "id": 2, "menuId": 1, "title": "Blog", "url": "/blog", "pageId": 2, "target": "_self", "position": 1, "depth": 0, "parentId": null, "isExpanded": false, "attributes": {} },
+    { "id": 3, "menuId": 1, "title": "About", "url": "/about", "pageId": 3, "target": "_self", "position": 2, "depth": 0, "parentId": null, "isExpanded": false, "attributes": {} },
+    { "id": 4, "menuId": 1, "title": "Contact", "url": "/contact", "pageId": 4, "target": "_self", "position": 3, "depth": 0, "parentId": null, "isExpanded": false, "attributes": {} },
+    { "id": 5, "menuId": 2, "title": "Privacy Policy", "url": "/privacy-policy", "pageId": 5, "target": "_self", "position": 0, "depth": 0, "parentId": null, "isExpanded": false, "attributes": {} },
+    { "id": 6, "menuId": 2, "title": "About", "url": "/about", "pageId": 3, "target": "_self", "position": 1, "depth": 0, "parentId": null, "isExpanded": false, "attributes": {} }
+  ]
+}


### PR DESCRIPTION
## Summary

5 starter templates with seed data, plus CLI template selection.

| Template | Content Types | Block Types | Pages | For |
|---|---|---|---|---|
| blog | 2 | 4 | 5 | Personal/company blogs |
| marketing | 3 | 8 | 5 | Product/business sites |
| wordpress | 2 | 5 | 8 | WordPress migrants |
| drupal | 4 | 8 | 10 | Drupal migrants |
| college | 6 | 10 | 12 | Higher education |

Usage: `npx create-wolly my-site --template blog`

🤖 Generated with [Claude Code](https://claude.com/claude-code)