### PR TITLE
fix: close preview token privilege escalation

### DIFF
--- a/packages/admin/src/lib/components/PreviewPanel.svelte
+++ b/packages/admin/src/lib/components/PreviewPanel.svelte
@@ -27,7 +27,8 @@
 
   function buildPreviewUrl(s: string): string {
     if (!siteUrl || !previewToken) return 'about:blank';
-    return `${siteUrl}/preview/${s}?token=${previewToken}`;
+    // Token is sent via httpOnly cookie (wolly_preview), not in URL
+    return `${siteUrl}/preview/${s}`;
   }
 
   let previewUrl = $state('about:blank');

--- a/packages/server/src/api/admin/auth.ts
+++ b/packages/server/src/api/admin/auth.ts
@@ -285,7 +285,7 @@ app.post('/preview-session', authMiddleware, async (c) => {
   const payload = c.get('jwtPayload');
   const now = Math.floor(Date.now() / 1000);
   const token = await sign(
-    { sub: payload.sub, email: payload.email, role: payload.role, exp: now + 600 },
+    { sub: payload.sub, email: payload.email, role: payload.role, purpose: 'preview', exp: now + 600 },
     env.JWT_SECRET,
     'HS256',
   );

--- a/packages/server/src/api/content/preview.ts
+++ b/packages/server/src/api/content/preview.ts
@@ -20,13 +20,17 @@ import {
  */
 const previewAuth = createMiddleware(async (c, next) => {
   const token = c.req.header('Authorization')?.replace('Bearer ', '')
-    || getCookie(c, 'wolly_preview')
-    || c.req.query('token');
+    || getCookie(c, 'wolly_preview');
   if (!token) {
     return c.json({ errors: [{ code: 'UNAUTHORIZED', message: 'Preview requires authentication' }] }, 401);
   }
   try {
-    await verify(token, env.JWT_SECRET, 'HS256');
+    const payload = (await verify(token, env.JWT_SECRET, 'HS256')) as unknown as { purpose?: string };
+    // Accept both preview-scoped tokens and full session tokens
+    // (editors need to preview from the admin panel using their session)
+    if (payload.purpose && payload.purpose !== 'preview') {
+      return c.json({ errors: [{ code: 'UNAUTHORIZED', message: 'Invalid token type' }] }, 401);
+    }
     await next();
   } catch {
     return c.json({ errors: [{ code: 'UNAUTHORIZED', message: 'Invalid token' }] }, 401);

--- a/packages/server/tests/content-api.test.ts
+++ b/packages/server/tests/content-api.test.ts
@@ -321,11 +321,9 @@ describe('GET /api/content/preview/pages/:slug', () => {
     expect(res.status).toBe(401);
   });
 
-  it('returns page data with valid query-param token', async () => {
+  it('rejects query-param token (security: prevents URL leakage)', async () => {
     const res = await get(`/api/content/preview/pages/home?token=${authToken}`);
-    expect(res.status).toBe(200);
-    const body = await res.json();
-    expect(body.data.slug).toBe('home');
+    expect(res.status).toBe(401);
   });
 
   it('returns page data with valid token (Authorization header)', async () => {


### PR DESCRIPTION
Preview tokens now carry purpose: 'preview', URL query-string token removed.