### PR TITLE
Add pull request CI and maintenance deploy guard

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -10,6 +10,7 @@ on:
       - '**/*.md'
       - '**/*.mdx'
       - '.github/workflows/**'
+      - '.github/dependabot.yml'
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,71 @@
+name: Pull Request CI
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  wollycms:
+    name: WollyCMS validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prepare SvelteKit types
+        run: npx --workspace=packages/admin svelte-kit sync
+
+      - name: Run tests
+        run: npm test
+
+      - name: Build server and admin
+        run: npm run build
+
+      - name: Build Cloudflare Worker
+        run: npm run build:worker
+
+      - name: Check admin CSP
+        run: node scripts/check-admin-csp.mjs
+
+  docs:
+    name: Docs validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: apps/docs
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: apps/docs/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build docs
+        run: npm run build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,7 @@ on:
       - '**/*.md'
       - '**/*.mdx'
       - '.github/workflows/**'
+      - '.github/dependabot.yml'
   workflow_dispatch:
     inputs:
       environment:


### PR DESCRIPTION
## Summary
- add non-deploying pull request validation for WollyCMS and docs
- build the Cloudflare Worker and run the admin CSP regression guard
- prevent Dependabot configuration-only commits from triggering CMS image/deploy workflows

## Validation
- `npm ci`
- `npx --workspace=packages/admin svelte-kit sync`
- `npm test` (240 tests)
- `npm run build`
- `npm run build:worker`
- `node scripts/check-admin-csp.mjs`
- `npm ci --prefix apps/docs`
- `npm run build --prefix apps/docs`

No production deployment is intended from this workflow-only change.