### PR TITLE
Add opt-in media cache recovery key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,9 @@ RATE_LIMIT_WINDOW_MS=900000
 # Media Storage
 MEDIA_STORAGE=local
 MEDIA_DIR=./uploads
+# Optional recovery key appended to public media URLs. Change it to bypass
+# previously cached responses without renaming or rewriting media objects.
+MEDIA_CACHE_VERSION=
 # For Cloudflare R2 (recommended for production):
 # MEDIA_STORAGE=s3
 # S3_ENDPOINT=https://<account-id>.r2.cloudflarestorage.com

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -87,6 +87,7 @@ jobs:
           NODE_ENV = "production"
           DATABASE_URL = "d1:DB"
           MEDIA_STORAGE = "r2"
+          MEDIA_CACHE_VERSION = "${{ vars.MEDIA_CACHE_VERSION }}"
           CORS_ORIGINS = "${{ vars.CORS_ORIGINS }}"
           SITE_URL = "${{ vars.SITE_URL }}"
           GOOGLE_CLIENT_ID = "${{ secrets.GOOGLE_CLIENT_ID }}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -115,6 +115,7 @@ jobs:
           NODE_ENV = "production"
           DATABASE_URL = "d1:DB"
           MEDIA_STORAGE = "r2"
+          MEDIA_CACHE_VERSION = "${{ vars.MEDIA_CACHE_VERSION }}"
           CORS_ORIGINS = "${{ vars.CORS_ORIGINS }}"
           SITE_URL = "${{ vars.SITE_URL }}"
           GOOGLE_CLIENT_ID = "${{ secrets.GOOGLE_CLIENT_ID }}"

--- a/README.md
+++ b/README.md
@@ -209,6 +209,7 @@ All configuration is via environment variables. See [`.env.example`](.env.exampl
 | `CORS_ORIGINS` | `*` | Allowed origins (comma-separated). **Set in production** |
 | `MEDIA_STORAGE` | `local` | Storage backend: `local` or `s3` |
 | `MEDIA_DIR` | `./uploads` | Local media storage path |
+| `MEDIA_CACHE_VERSION` | — | Optional recovery key appended to public media URLs to bypass stale browser caches |
 | `S3_ENDPOINT` | — | S3/R2 endpoint for remote media storage |
 | `S3_BUCKET` | — | S3/R2 bucket name |
 | `SITE_URL` | `http://localhost:4322` | Frontend URL for webhooks/preview |

--- a/apps/docs/src/content/docs/deployment/cloudflare.md
+++ b/apps/docs/src/content/docs/deployment/cloudflare.md
@@ -61,6 +61,8 @@ bucket_name = "wollycms-media"
 NODE_ENV = "production"
 DATABASE_URL = "d1:DB"
 MEDIA_STORAGE = "r2"
+# Optional: change this value to force browsers to request fresh media URLs.
+MEDIA_CACHE_VERSION = ""
 CORS_ORIGINS = "https://your-site.example.com"
 SITE_URL = "https://your-site.example.com"
 
@@ -115,6 +117,7 @@ Make sure the domain's DNS is managed by Cloudflare.
 | `JWT_SECRET` | Yes | Secret for signing JWT tokens (set as secret) |
 | `DATABASE_URL` | Yes | `d1:DB` for D1 binding |
 | `MEDIA_STORAGE` | Yes | `r2` for R2 storage |
+| `MEDIA_CACHE_VERSION` | No | Recovery key appended to media URLs; change it to bypass stale browser caches |
 | `CORS_ORIGINS` | Yes | Comma-separated allowed origins |
 | `SITE_URL` | Yes | Your frontend site URL (for sitemaps, OG images) |
 | `NODE_ENV` | No | `production` recommended |

--- a/packages/server/src/api/content/media.ts
+++ b/packages/server/src/api/content/media.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono';
 import { eq } from 'drizzle-orm';
 import { getDb } from '../../db/index.js';
 import { media } from '../../db/schema/index.js';
+import { env } from '../../env.js';
 import { getStorage } from '../../media/storage.js';
 
 const VALID_VARIANTS = ['original', 'thumbnail', 'medium', 'large', 'info'] as const;
@@ -9,6 +10,18 @@ type Variant = (typeof VALID_VARIANTS)[number];
 
 /** One year in seconds for immutable cache headers. */
 const CACHE_MAX_AGE = 31536000;
+
+/**
+ * Append an opt-in cache version without changing the underlying media key.
+ * Relative URLs are intentional because Workers serves R2 media at /media/*.
+ */
+export function versionMediaUrl(url: string, version: string): string {
+  const normalizedVersion = version.trim();
+  if (!normalizedVersion) return url;
+
+  const separator = url.includes('?') ? '&' : '?';
+  return `${url}${separator}v=${encodeURIComponent(normalizedVersion)}`;
+}
 
 /**
  * Determine Content-Type for a variant file.
@@ -64,8 +77,14 @@ app.get('/:id/:variant', async (c) => {
 
   // For "info" variant, return full metadata as JSON with public URLs
   if (variant === 'info') {
+    const cacheVersion = env.MEDIA_CACHE_VERSION;
     const variantUrls = record.variants && typeof record.variants === 'object'
-      ? Object.fromEntries(Object.entries(record.variants as Record<string, string>).map(([k, v]) => [k, storage.getUrl(v)]))
+      ? Object.fromEntries(
+          Object.entries(record.variants as Record<string, string>).map(([key, value]) => [
+            key,
+            versionMediaUrl(storage.getUrl(value), cacheVersion),
+          ]),
+        )
       : {};
 
     return c.json({
@@ -79,7 +98,7 @@ app.get('/:id/:variant', async (c) => {
         height: record.height,
         altText: record.altText,
         title: record.title,
-        url: storage.getUrl(record.path),
+        url: versionMediaUrl(storage.getUrl(record.path), cacheVersion),
         variantUrls,
         variants: record.variants,
         metadata: record.metadata,
@@ -101,7 +120,11 @@ app.get('/:id/:variant', async (c) => {
 
   // For external storage (S3/R2), redirect to the public CDN URL
   if (storage.isExternal) {
-    const publicUrl = storage.getUrl(filePath);
+    const cacheVersion = env.MEDIA_CACHE_VERSION.trim();
+    const publicUrl = versionMediaUrl(storage.getUrl(filePath), cacheVersion);
+    if (cacheVersion) {
+      c.header('Cache-Control', 'no-store');
+    }
     return c.redirect(publicUrl, 302);
   }
 

--- a/packages/server/src/env.ts
+++ b/packages/server/src/env.ts
@@ -19,6 +19,7 @@ interface EnvConfig {
   DATABASE_URL: string;
   MEDIA_STORAGE: string;
   MEDIA_DIR: string;
+  MEDIA_CACHE_VERSION: string;
   JWT_SECRET: string;
   CORS_ORIGINS: string;
   RATE_LIMIT_AUTH: number;
@@ -53,6 +54,7 @@ function readProcessEnv(): EnvConfig {
     DATABASE_URL: p.DATABASE_URL || 'sqlite:./data/wolly.db',
     MEDIA_STORAGE: p.MEDIA_STORAGE || 'local',
     MEDIA_DIR: p.MEDIA_DIR || './uploads',
+    MEDIA_CACHE_VERSION: p.MEDIA_CACHE_VERSION || '',
     JWT_SECRET: p.JWT_SECRET || 'dev-secret-change-me',
     CORS_ORIGINS: p.CORS_ORIGINS || '*',
     RATE_LIMIT_AUTH: parseInt(p.RATE_LIMIT_AUTH || '10', 10),
@@ -106,6 +108,7 @@ export function initEnvFromBindings(bindings: Record<string, unknown>): void {
     DATABASE_URL: b('DATABASE_URL', 'd1:'),
     MEDIA_STORAGE: b('MEDIA_STORAGE', 'r2'),
     MEDIA_DIR: b('MEDIA_DIR', './uploads'),
+    MEDIA_CACHE_VERSION: b('MEDIA_CACHE_VERSION'),
     JWT_SECRET: (() => {
       const secret = b('JWT_SECRET');
       if (!secret) throw new Error('JWT_SECRET binding is required');

--- a/packages/server/tests/content-api.test.ts
+++ b/packages/server/tests/content-api.test.ts
@@ -1,4 +1,7 @@
-import { describe, it, expect, beforeAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { versionMediaUrl } from '../src/api/content/media.js';
+import { env } from '../src/env.js';
+import { initR2Storage, resetStorage } from '../src/media/storage.js';
 import { setupTestDatabase } from './setup.js';
 
 let app: typeof import('../src/app.js').default;
@@ -204,6 +207,20 @@ describe('GET /api/content/taxonomies/:slug/terms', () => {
 });
 
 describe('GET /api/content/media/:id/:variant', () => {
+  it('leaves media URLs unchanged when cache versioning is disabled', () => {
+    expect(versionMediaUrl('/media/example.webp', '')).toBe('/media/example.webp');
+    expect(versionMediaUrl('/media/example.webp', '   ')).toBe('/media/example.webp');
+  });
+
+  it('adds an encoded cache version without changing the media path', () => {
+    expect(versionMediaUrl('/media/example.webp', 'svcc 2026-08-25')).toBe(
+      '/media/example.webp?v=svcc%202026-08-25',
+    );
+    expect(versionMediaUrl('/media/example.webp?download=1', 'incident-1')).toBe(
+      '/media/example.webp?download=1&v=incident-1',
+    );
+  });
+
   it('returns media info for info variant', async () => {
     const res = await get('/api/content/media/1/info');
     expect(res.status).toBe(200);
@@ -241,6 +258,51 @@ describe('GET /api/content/media/:id/:variant', () => {
   it('returns 400 for invalid variant', async () => {
     const res = await get('/api/content/media/1/invalid');
     expect(res.status).toBe(400);
+  });
+});
+
+describe('R2 media cache recovery redirects', () => {
+  const originalCacheVersion = env.MEDIA_CACHE_VERSION;
+
+  beforeAll(() => {
+    initR2Storage({});
+  });
+
+  afterAll(() => {
+    env.MEDIA_CACHE_VERSION = originalCacheVersion;
+    resetStorage();
+  });
+
+  it('preserves existing redirect behavior when cache versioning is disabled', async () => {
+    env.MEDIA_CACHE_VERSION = '';
+
+    const res = await get('/api/content/media/1/original');
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toMatch(/^\/media\/[^?]+$/);
+    expect(res.headers.get('cache-control')).toBeNull();
+  });
+
+  it('uses a fresh cache key and disables redirect caching when enabled', async () => {
+    env.MEDIA_CACHE_VERSION = 'svcc-20260825-incident-1';
+
+    const res = await get('/api/content/media/1/original');
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get('location')).toMatch(
+      /^\/media\/[^?]+\?v=svcc-20260825-incident-1$/,
+    );
+    expect(res.headers.get('cache-control')).toBe('no-store');
+  });
+
+  it('versions media URLs returned by the info endpoint', async () => {
+    env.MEDIA_CACHE_VERSION = 'svcc-20260825-incident-1';
+
+    const res = await get('/api/content/media/1/info');
+    const body = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(body.data.url).toMatch(/\?v=svcc-20260825-incident-1$/);
   });
 });
 


### PR DESCRIPTION
## Summary

- add an optional MEDIA_CACHE_VERSION setting that appends a version query to public media URLs
- send no-store on versioned R2/S3 redirects so future recovery keys take effect promptly
- preserve existing behavior when the setting is empty
- document the setting and pass it through Cloudflare deployment workflows

## Safety

- no D1 content changes
- no R2 object changes
- no media record rewrites
- production-only canary deployed from this branch; catalog and wollycms-site were excluded
- prior production Worker version recorded for rollback

## Validation

- 245 server tests passed
- server and admin production builds passed
- Worker build passed
- admin CSP guard passed
- production workflow run 32883658119 passed
- all 14 CMS-backed homepage image requests returned valid image responses under the new cache key
- Firefox rendered 19 of 19 homepage images with nonzero dimensions and zero console errors