### PR TITLE
fix(i18n): honor locale in preview endpoint and page import dedup

### DIFF
--- a/apps/docs/src/content/docs/concepts/preview.md
+++ b/apps/docs/src/content/docs/concepts/preview.md
@@ -54,3 +54,10 @@ const page = await wolly.pages.preview(slug, token);
 :::tip
 Configure your CMS's `SITE_URL` environment variable to point to your frontend. The preview button uses this URL to construct the preview link.
 :::
+
+## Multilingual previews
+
+The admin preview URL includes the edited page’s `locale`. Your frontend preview
+route must forward that parameter to `/api/content/preview/pages/:slug` along
+with preview authentication. This selects the correct translation when multiple
+languages share a slug. Omitting `locale` retains slug-only matching.

--- a/docs/architecture/api-design.md
+++ b/docs/architecture/api-design.md
@@ -228,10 +228,12 @@ GET /api/content/schemas
 
 ```
 GET /api/content/preview/pages/:slug
-  ?token=JWT                          — JWT auth via query param
+  ?locale=fr                          — Select a same-slug translation (optional)
+  &token=JWT                          — JWT auth via query param
   Authorization: Bearer JWT           — or via header
 
-  — Returns page data regardless of publish status (drafts included)
+  — Returns page data including locale regardless of publish status (drafts included)
+  — Omitting locale retains slug-only matching; preview frontends should forward it
   — Used by the Astro SSR preview route for live preview in admin editor
 ```
 

--- a/docs/architecture/astro-integration.md
+++ b/docs/architecture/astro-integration.md
@@ -422,7 +422,9 @@ export default defineConfig({
 ## Preview Mode (Draft Content)
 
 For editors to preview unpublished changes. The preview route is SSR (not
-prerendered) and fetches from the authenticated preview API endpoint:
+prerendered) and fetches from the authenticated preview API endpoint. Forward the
+`locale` query parameter from the admin preview URL so same-slug translations
+resolve to the edited language. Without it, preview retains slug-only matching:
 
 ```astro
 ---
@@ -431,13 +433,18 @@ export const prerender = false;
 
 const { slug } = Astro.params;
 const token = Astro.url.searchParams.get('token');
+const locale = Astro.url.searchParams.get('locale');
 
 if (!token || !slug) {
   return new Response('Missing token or slug', { status: 400 });
 }
 
 const API_BASE = 'http://localhost:4321/api/content';
-const pageRes = await fetch(`${API_BASE}/preview/pages/${slug}?token=${token}`);
+const previewUrl = new URL(`${API_BASE}/preview/pages/${slug.split('/').map(encodeURIComponent).join('%2F')}`);
+if (locale) previewUrl.searchParams.set('locale', locale);
+const pageRes = await fetch(previewUrl, {
+  headers: { Authorization: `Bearer ${token}` },
+});
 if (!pageRes.ok) {
   return new Response(`Page not found: ${slug}`, { status: 404 });
 }

--- a/examples/college-site/src/pages/preview/[...slug].astro
+++ b/examples/college-site/src/pages/preview/[...slug].astro
@@ -7,7 +7,8 @@ import { wolly } from '../../lib/wolly';
 import * as blockComponents from '../../lib/blocks';
 
 const { slug } = Astro.params;
-const token = Astro.cookies.get('wolly_preview')?.value;
+const token = Astro.url.searchParams.get('token') || Astro.cookies.get('wolly_preview')?.value;
+const locale = Astro.url.searchParams.get('locale');
 
 if (!token || !slug) {
   return new Response('Preview authorization is required', { status: 401 });
@@ -15,7 +16,10 @@ if (!token || !slug) {
 
 const API_BASE = 'http://localhost:4321/api/content';
 
-const pageRes = await fetch(`${API_BASE}/preview/pages/${slug}`, {
+const previewUrl = new URL(`${API_BASE}/preview/pages/${slug.split('/').map(encodeURIComponent).join('%2F')}`);
+if (locale) previewUrl.searchParams.set('locale', locale);
+
+const pageRes = await fetch(previewUrl, {
   headers: { Authorization: `Bearer ${token}` },
 });
 if (!pageRes.ok) {

--- a/packages/admin/src/lib/components/PreviewPanel.svelte
+++ b/packages/admin/src/lib/components/PreviewPanel.svelte
@@ -6,10 +6,12 @@
 
   let {
     slug,
+    locale,
     visible = false,
     onBlockSelect,
   }: {
     slug: string;
+    locale?: string;
     visible: boolean;
     onBlockSelect?: (pbId: string, region: string) => void;
   } = $props();
@@ -30,7 +32,10 @@
     // Token passed via query param for cross-origin iframe preview.
     // Safe because preview tokens are purpose-scoped (can't access admin routes)
     // and short-lived (10 minutes).
-    return `${siteUrl}/preview/${s}?token=${previewToken}`;
+    // Locale disambiguates slugs shared across locales (slugs are only unique
+    // per locale); frontends forward it to /api/content/preview/pages/:slug.
+    const localeParam = locale ? `&locale=${encodeURIComponent(locale)}` : '';
+    return `${siteUrl}/preview/${s}?token=${previewToken}${localeParam}`;
   }
 
   let previewUrl = $state('about:blank');

--- a/packages/admin/src/routes/pages/[id]/+page.svelte
+++ b/packages/admin/src/routes/pages/[id]/+page.svelte
@@ -522,7 +522,7 @@
       </div>
     </div>
 
-    <PreviewPanel bind:this={previewPanel} slug={pageData.slug} visible={showPreview}
+    <PreviewPanel bind:this={previewPanel} slug={pageData.slug} locale={pageData.locale} visible={showPreview}
       onBlockSelect={(pbId, region) => { blockEditor?.scrollToBlock(pbId); }} />
   </div>
 {/if}

--- a/packages/server/src/api/admin/export-import.ts
+++ b/packages/server/src/api/admin/export-import.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import { getDb } from '../../db/index.js';
 import { requireRole } from '../../auth/rbac.js';
 import {
@@ -119,8 +119,22 @@ app.post('/import', async (c) => {
   // 4. Media metadata (no dependencies besides users, which we skip)
   await importById(media, media.id, body.media, 'media');
 
-  // 5. Pages (depends on contentTypes)
-  await importBySlug(pages, pages.slug, body.pages, 'pages');
+  // 5. Pages (depends on contentTypes) — dedup on (slug, locale), not slug
+  // alone: slugs are only unique per locale (pages_slug_locale_unique), so
+  // slug-only dedup silently drops translations that share a slug.
+  if (body.pages?.length) {
+    for (const row of body.pages as Array<{ slug: string; locale?: string }>) {
+      const [existing] = await db
+        .select({ id: pages.id })
+        .from(pages)
+        .where(and(eq(pages.slug, row.slug), eq(pages.locale, row.locale ?? 'en')))
+        .limit(1);
+      if (!existing) {
+        await db.insert(pages).values(row as typeof pages.$inferInsert);
+      }
+    }
+    stats.pages = body.pages.length;
+  }
 
   // 6. Blocks (depends on blockTypes)
   await importById(blocks, blocks.id, body.blocks, 'blocks');

--- a/packages/server/src/api/content/preview.ts
+++ b/packages/server/src/api/content/preview.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { eq, asc } from 'drizzle-orm';
+import { and, eq, asc } from 'drizzle-orm';
 import { verify } from 'hono/jwt';
 import { getCookie } from 'hono/cookie';
 import { createMiddleware } from 'hono/factory';
@@ -50,10 +50,19 @@ app.use('/*', previewAuth);
 /**
  * GET /pages/:slug - Get page with blocks regardless of status (for live preview).
  * Same response format as the public content API.
+ *
+ * Accepts an optional `locale` query param: slugs are only unique per locale
+ * (pages_slug_locale_unique), so without it a slug shared across locales
+ * resolves to an arbitrary translation. Omitting `locale` keeps the previous
+ * slug-only behavior for backward compatibility.
  */
 app.get('/pages/:slug{.+}', async (c) => {
   const db = getDb();
   const slug = c.req.param('slug');
+  const locale = c.req.query('locale');
+
+  const conditions = [eq(pages.slug, slug)];
+  if (locale) conditions.push(eq(pages.locale, locale));
 
   const pageRows = await db
     .select({
@@ -63,6 +72,7 @@ app.get('/pages/:slug{.+}', async (c) => {
       title: pages.title,
       slug: pages.slug,
       status: pages.status,
+      locale: pages.locale,
       fields: pages.fields,
       createdAt: pages.createdAt,
       updatedAt: pages.updatedAt,
@@ -70,7 +80,7 @@ app.get('/pages/:slug{.+}', async (c) => {
     })
     .from(pages)
     .innerJoin(contentTypes, eq(pages.typeId, contentTypes.id))
-    .where(eq(pages.slug, slug))
+    .where(and(...conditions))
     .limit(1);
 
   if (pageRows.length === 0) {
@@ -125,6 +135,7 @@ app.get('/pages/:slug{.+}', async (c) => {
       title: page.title,
       slug: page.slug,
       status: page.status,
+      locale: page.locale,
       fields: normalizeContentFields(page.fields, page.pageFieldsSchema),
       regions,
       meta: {

--- a/packages/server/src/cli.ts
+++ b/packages/server/src/cli.ts
@@ -284,7 +284,7 @@ async function main() {
 
       const { readFileSync: readFile } = await import('fs');
       const { getDb } = await import('./db/index.js');
-      const { eq } = await import('drizzle-orm');
+      const { and, eq } = await import('drizzle-orm');
       const schema = await import('./db/schema/index.js');
 
       let data: Record<string, unknown>;
@@ -305,7 +305,7 @@ async function main() {
         name: string,
         table: any,
         rows: unknown[],
-        dedup: (row: Record<string, unknown>) => ReturnType<typeof eq>,
+        dedup: (row: Record<string, unknown>) => ReturnType<typeof eq> | ReturnType<typeof and>,
       ) => {
         let imported = 0;
         for (const row of rows as Record<string, unknown>[]) {
@@ -324,7 +324,8 @@ async function main() {
       if (d.blockTypes?.length) await importTable('blockTypes', schema.blockTypes, d.blockTypes, (r) => eq(schema.blockTypes.slug, r.slug as string));
       if (d.taxonomies?.length) await importTable('taxonomies', schema.taxonomies, d.taxonomies, (r) => eq(schema.taxonomies.slug, r.slug as string));
       if (d.terms?.length) await importTable('terms', schema.terms, d.terms, (r) => eq(schema.terms.slug, r.slug as string));
-      if (d.pages?.length) await importTable('pages', schema.pages, d.pages, (r) => eq(schema.pages.slug, r.slug as string));
+      // Pages dedup on (slug, locale): slugs are only unique per locale.
+      if (d.pages?.length) await importTable('pages', schema.pages, d.pages, (r) => and(eq(schema.pages.slug, r.slug as string), eq(schema.pages.locale, (r.locale as string | undefined) ?? 'en')));
       if (d.blocks?.length) await importTable('blocks', schema.blocks, d.blocks, (r) => eq(schema.blocks.id, r.id as number));
       if (d.pageBlocks?.length) await importTable('pageBlocks', schema.pageBlocks, d.pageBlocks, (r) => eq(schema.pageBlocks.id, r.id as number));
       if (d.menus?.length) await importTable('menus', schema.menus, d.menus, (r) => eq(schema.menus.slug, r.slug as string));

--- a/packages/server/tests/admin-api.test.ts
+++ b/packages/server/tests/admin-api.test.ts
@@ -681,6 +681,42 @@ describe('Admin Export/Import', () => {
     expect(body.data.imported).toBe(true);
     expect(body.data.stats.pages).toBeGreaterThan(0);
   });
+
+  it('POST /import preserves same-slug pages across locales', async () => {
+    // Slugs are only unique per (slug, locale) — an import containing a
+    // translation pair sharing a slug must keep both rows.
+    const now = new Date().toISOString();
+    const payload = {
+      version: 2,
+      pages: [
+        {
+          typeId: 1, title: 'Localized EN', slug: 'import-locale-test',
+          status: 'published', locale: 'en', fields: {},
+          createdAt: now, updatedAt: now, publishedAt: now,
+        },
+        {
+          typeId: 1, title: 'Localisé FR', slug: 'import-locale-test',
+          status: 'published', locale: 'fr', fields: {},
+          createdAt: now, updatedAt: now, publishedAt: now,
+        },
+      ],
+    };
+
+    const res = await json('/import', 'POST', payload);
+    expect(res.status).toBe(200);
+
+    const en = await app.request('/api/content/pages/import-locale-test?locale=en');
+    expect(en.status).toBe(200);
+    expect((await en.json()).data.title).toBe('Localized EN');
+
+    const fr = await app.request('/api/content/pages/import-locale-test?locale=fr');
+    expect(fr.status).toBe(200);
+    expect((await fr.json()).data.title).toBe('Localisé FR');
+
+    // Re-importing dedups on (slug, locale) — no unique-constraint failure
+    const again = await json('/import', 'POST', payload);
+    expect(again.status).toBe(200);
+  });
 });
 
 // --- RBAC ---

--- a/packages/server/tests/content-api.test.ts
+++ b/packages/server/tests/content-api.test.ts
@@ -452,6 +452,56 @@ describe('GET /api/content/preview/pages/:slug', () => {
     });
     expect(res.status).toBe(404);
   });
+
+  describe('locale disambiguation', () => {
+    // Slugs are only unique per locale, so a slug can exist in several
+    // locales at once. Preview must be able to target a specific one.
+    beforeAll(async () => {
+      const res = await adminJson('/pages', 'POST', {
+        title: 'Accueil',
+        slug: 'home',
+        typeId: 1,
+        status: 'draft',
+        locale: 'fr',
+      });
+      expect(res.status).toBe(201);
+    });
+
+    function preview(path: string) {
+      return app.request(`/api/content/preview/pages/${path}`, {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${authToken}` },
+      });
+    }
+
+    it('includes the page locale in the response', async () => {
+      const res = await preview('home?locale=en');
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data.locale).toBe('en');
+    });
+
+    it('filters by ?locale= for slugs shared across locales', async () => {
+      const res = await preview('home?locale=fr');
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data.locale).toBe('fr');
+      expect(body.data.title).toBe('Accueil');
+      expect(body.data.status).toBe('draft');
+    });
+
+    it('keeps slug-only matching when locale is omitted (back-compat)', async () => {
+      const res = await preview('home');
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      expect(body.data.slug).toBe('home');
+    });
+
+    it('returns 404 when the slug does not exist in the requested locale', async () => {
+      const res = await preview('home?locale=de');
+      expect(res.status).toBe(404);
+    });
+  });
 });
 
 // --- Content API Tracking Scripts ---


### PR DESCRIPTION
## Problem

Slugs are unique **per locale** (`pages_slug_locale_unique`), and the i18n docs advertise that the same slug can exist in several languages. Three code paths ignore locale, which breaks that documented capability:

1. **Preview returns an arbitrary translation.** `GET /api/content/preview/pages/:slug` matches on slug alone with `LIMIT 1`. With `about` existing in `en` and `fr`, an editor previewing one page can be shown the other language's content. There was no way to disambiguate: the endpoint accepted no locale, the response carried no `locale` field, and the admin `PreviewPanel` built the iframe URL from the slug alone.
2. **Import silently drops translations.** `POST /api/admin/import` deduped pages by slug alone (`importBySlug`), so importing an export containing a same-slug translation pair kept only one of them — export → import loses content on exactly the multilingual sites the i18n feature targets. The `wolly import` CLI had the same behavior.

## Changes

- `packages/server/src/api/content/preview.ts` — accepts an optional `?locale=` filter and includes the page's `locale` in the response. **Backward compatible:** omitting `locale` keeps the previous slug-only matching.
- `packages/admin/src/lib/components/PreviewPanel.svelte` + `pages/[id]/+page.svelte` — the preview iframe URL now carries the edited page's locale (`/preview/{slug}?token=…&locale=…`) so frontends can forward it to the preview API. Frontends that ignore the extra param behave exactly as before.
- `packages/server/src/api/admin/export-import.ts` — pages dedup on `(slug, locale)` instead of slug alone. Rows without a `locale` fall back to `'en'`, matching the column default, so existing v1 exports import unchanged.
- `packages/server/src/cli.ts` — same `(slug, locale)` dedup for `wolly import`.

## Tests

- `tests/content-api.test.ts` — preview: creates a second page sharing the seeded `home` slug in locale `fr`, then asserts `?locale=fr` returns it (draft included), `?locale=en` returns the English page, the response includes `locale`, omitting the param keeps slug-only matching, and an unknown locale 404s.
- `tests/admin-api.test.ts` — import: a v2 payload with a same-slug `en`/`fr` pair imports both (each retrievable via the public API with its locale), and re-importing the same payload dedups cleanly with no unique-constraint failure.

`npm run test` — 250 passed. `npm run build:server` and `npm run build:admin` both pass.

## Notes

- Not addressed here (happy to follow up): `POST /api/content/batch` keys pages by slug so same-slug translations still collide in its response, and `@wollycms/astro`'s client never serializes the `locale` param (`PageListParams.locale` is declared but dropped; `getBySlug` has no locale argument despite the i18n docs showing one). Kept out to keep this PR focused on the server/admin preview + import paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
