### PR TITLE
fix(astro): serialize locale and status in the content client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,14 @@ jobs:
       - name: Run tests
         run: npm test
 
+      - name: Test Astro client and helpers
+        working-directory: packages/astro
+        run: npx vitest run
+
+      - name: Type-check Astro integration
+        working-directory: packages/astro
+        run: npx tsc --noEmit
+
       - name: Build server and admin
         run: npm run build
 

--- a/packages/astro/src/client.ts
+++ b/packages/astro/src/client.ts
@@ -39,12 +39,15 @@ export class WollyClient {
       if (params?.sort) searchParams.set('sort', params.sort);
       if (params?.limit) searchParams.set('limit', String(params.limit));
       if (params?.offset) searchParams.set('offset', String(params.offset));
+      if (params?.status) searchParams.set('status', params.status);
+      if (params?.locale) searchParams.set('locale', params.locale);
       const qs = searchParams.toString();
       return this.fetch(`/pages${qs ? `?${qs}` : ''}`);
     },
 
-    getBySlug: async (slug: string): Promise<Page> => {
-      const res = await this.fetch<ApiResponse<Page>>(`/pages/${slug}`);
+    getBySlug: async (slug: string, options?: { locale?: string }): Promise<Page> => {
+      const qs = options?.locale ? `?locale=${encodeURIComponent(options.locale)}` : '';
+      const res = await this.fetch<ApiResponse<Page>>(`/pages/${slug}${qs}`);
       return res.data;
     },
   };
@@ -81,10 +84,11 @@ export class WollyClient {
   };
 
   readonly search = {
-    query: async (q: string, options?: { type?: string; limit?: number }): Promise<{ data: Array<{ id: number; type: string; title: string; slug: string; description: string | null }>; meta: { total: number; query: string } }> => {
+    query: async (q: string, options?: { type?: string; limit?: number; locale?: string }): Promise<{ data: Array<{ id: number; type: string; title: string; slug: string; description: string | null }>; meta: { total: number; query: string } }> => {
       const params = new URLSearchParams({ q });
       if (options?.type) params.set('type', options.type);
       if (options?.limit) params.set('limit', String(options.limit));
+      if (options?.locale) params.set('locale', options.locale);
       return this.fetch(`/search?${params}`);
     },
   };

--- a/packages/astro/tests/client.test.ts
+++ b/packages/astro/tests/client.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createClient } from '../src/client.js';
+
+const API = 'http://cms.test/api/content';
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+function requestedUrl(call = 0): URL {
+  return new URL(fetchMock.mock.calls[call][0] as string);
+}
+
+beforeEach(() => {
+  fetchMock = vi.fn(async () =>
+    new Response(JSON.stringify({ data: [], meta: { total: 0 } }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }),
+  );
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('client locale handling', () => {
+  const client = createClient({ apiUrl: API });
+
+  it('pages.list serializes locale and status', async () => {
+    await client.pages.list({ locale: 'fr', status: 'published', type: 'article' });
+    const url = requestedUrl();
+    expect(url.pathname).toBe('/api/content/pages');
+    expect(url.searchParams.get('locale')).toBe('fr');
+    expect(url.searchParams.get('status')).toBe('published');
+    expect(url.searchParams.get('type')).toBe('article');
+  });
+
+  it('pages.list omits locale when not provided', async () => {
+    await client.pages.list({ type: 'article' });
+    expect(requestedUrl().searchParams.has('locale')).toBe(false);
+  });
+
+  it('pages.getBySlug passes locale', async () => {
+    await client.pages.getBySlug('a-propos', { locale: 'fr' });
+    const url = requestedUrl();
+    expect(url.pathname).toBe('/api/content/pages/a-propos');
+    expect(url.searchParams.get('locale')).toBe('fr');
+  });
+
+  it('pages.getBySlug without options keeps the bare URL', async () => {
+    await client.pages.getBySlug('about');
+    const url = requestedUrl();
+    expect(url.pathname).toBe('/api/content/pages/about');
+    expect(url.search).toBe('');
+  });
+
+  it('search.query passes locale', async () => {
+    await client.search.query('hello', { locale: 'fr', limit: 5 });
+    const url = requestedUrl();
+    expect(url.pathname).toBe('/api/content/search');
+    expect(url.searchParams.get('q')).toBe('hello');
+    expect(url.searchParams.get('locale')).toBe('fr');
+    expect(url.searchParams.get('limit')).toBe('5');
+  });
+});


### PR DESCRIPTION
Follow-up to #121 (the "not addressed here" note in that PR).

## Problem

`@wollycms/astro`'s client cannot fetch non-default-locale content:

- `PageListParams` declares `locale` and `status`, but `pages.list()` never serializes them — passing `{ locale: 'fr' }` is silently dropped and the request falls back to the site's `defaultLocale`.
- `pages.getBySlug(slug)` has no locale parameter at all, even though the i18n docs show `client.pages.getBySlug(slug, { locale })`.
- `search.query()` has no locale option, though the server's `/search` endpoint supports `?locale=`.

Net effect: on a multilingual site, translated content is unreachable through the official client.

## Changes (`packages/astro/src/client.ts`)

- `pages.list()` serializes `params.locale` and `params.status` (both already declared in `PageListParams`).
- `pages.getBySlug(slug, options?: { locale?: string })` — matches the documented signature; the URL is unchanged when `options` is omitted.
- `search.query(q, { type?, limit?, locale? })` serializes `locale`.

No type changes needed — the params were already declared; they just never reached the wire. Fully backward compatible: all existing call sites produce byte-identical URLs.

## Tests

New `packages/astro/tests/client.test.ts` (same setup as the existing `richtext.test.ts`): mocks `fetch` and asserts the built URLs for all three methods, including the no-locale back-compat cases. `npx vitest run` in `packages/astro`: 7 passed (2 existing + 5 new); `tsc --noEmit` clean; the server suite is unaffected (245 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
