### PR TITLE
release: server and Astro 0.3.1

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## 0.3.1 — 2026-09-11
+
+Patch release for `@wollycms/server` and `@wollycms/astro`. `create-wolly`
+remains at 0.3.0.
+
+- Fix same-slug multilingual previews and preserve translations during API and
+  CLI imports by deduplicating pages on both slug and locale.
+- Forward locale in Astro page lists, page lookup, and search. Serialize the
+  existing page-list status option; the public API still returns published content.
+- Forward locale and accept admin preview tokens in the reference frontend, and
+  document the required locale forwarding for custom preview routes.
+- Run Astro integration tests and TypeScript checks in pull request CI.
+- Include fixes merged since 0.3.0: accessible rich-text heading anchors, stable
+  block drag-reordering, and optional media cache recovery configuration.
+
+Thanks to [Brent Cartier (@bcartier)](https://github.com/bcartier) for the
+multilingual fixes in [#121](https://github.com/WollyCMS/wollycms/pull/121) and
+[#122](https://github.com/WollyCMS/wollycms/pull/122).
+
 ## 2026-08-19
 
 ### Block drag-reorder jitter in the page editor

--- a/package-lock.json
+++ b/package-lock.json
@@ -9963,7 +9963,7 @@
     },
     "packages/astro": {
       "name": "@wollycms/astro",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "devDependencies": {
         "astro": "^7.1.6"
@@ -10537,7 +10537,7 @@
     },
     "packages/server": {
       "name": "@wollycms/server",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1100.0",

--- a/packages/astro/package.json
+++ b/packages/astro/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wollycms/astro",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "description": "Astro.js integration for WollyCMS — components, helpers, and route generation",
   "author": "Chad Wollenberg",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wollycms/server",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "engines": {
     "node": ">=22.0.0"

--- a/packages/server/tests/content-api.test.ts
+++ b/packages/server/tests/content-api.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import packageJson from '../package.json' with { type: 'json' };
 import { versionMediaUrl } from '../src/api/content/media.js';
 import { env } from '../src/env.js';
 import { initR2Storage, resetStorage } from '../src/media/storage.js';
@@ -43,7 +44,7 @@ describe('Health Check', () => {
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.status).toBe('ok');
-    expect(body.version).toBe('0.3.0');
+    expect(body.version).toBe(packageJson.version);
   });
 });
 


### PR DESCRIPTION
Prepare @wollycms/server and @wollycms/astro 0.3.1 so npm users receive the merged multilingual preview/import and Astro client fixes. Add release notes crediting @bcartier and covering fixes since 0.3.0. create-wolly remains unchanged at 0.3.0.

The health API test now checks the package version instead of hardcoding 0.3.0.

Validation: fresh npm ci; 250 server tests; 7 Astro tests and TypeScript check; server/admin builds; package entry-point and admin CSP checks; npm pack dry runs inspected for both packages.
